### PR TITLE
Modernized API Code for PHP 7

### DIFF
--- a/src/FMAPI/FileMaker.php
+++ b/src/FMAPI/FileMaker.php
@@ -41,9 +41,9 @@ define('FILEMAKER_FIND_FIELDMATCH', '==');
 
 /**#@+
  * Find logical operator constants.
-  * Use with the {@link FileMaker_Command_Find::setLogicalOperator()}  
+ * Use with the {@link FileMaker_Command_Find::setLogicalOperator()}
  * method.
-*/
+ */
 define('FILEMAKER_FIND_AND', 'and');
 define('FILEMAKER_FIND_OR', 'or');
 /**#@-*/
@@ -62,7 +62,7 @@ define('FILEMAKER_RULE_TIME_FIELD', 8);
 /**#@-*/
 
 /**#@+
- * Sort direction constants. 
+ * Sort direction constants.
  * Use with the {@link FileMaker_Command_Find::addSortRule()} and
  * {@link FileMaker_Command_CompoundFind::addSortRule()} methods.
  */
@@ -79,7 +79,7 @@ define('FILEMAKER_LOG_DEBUG', 7);
 /**#@-*/
 
 /**
- * Base FileMaker class. Defines database properties, connects to a database, 
+ * Base FileMaker class. Defines database properties, connects to a database,
  * and gets information about the API.
  *
  * @package FileMaker
@@ -92,7 +92,7 @@ class FileMaker
      * @var FileMaker_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Tests whether a variable is a FileMaker API Error.
@@ -102,7 +102,7 @@ class FileMaker
      * @static
      *
      */
-    static function isError($variable)
+    public static function isError($variable)
     {
         return is_a($variable, 'FileMaker_Error');
     }
@@ -113,7 +113,7 @@ class FileMaker
      * @return string API version.
      * @static
      */
-    function getAPIVersion()
+    public function getAPIVersion()
     {
         return FileMaker_Implementation::getAPIVersion();
     }
@@ -124,30 +124,30 @@ class FileMaker
      * @return string Minimum FileMaker Server version.
      * @static
      */
-    static function getMinServerVersion()
+    public static function getMinServerVersion()
     {
         return FileMaker_Implementation::getMinServerVersion();
     }
 
     /**
-     * FileMaker object constructor. 
-     * 
-     * If you want to use the constructor without specifying all the 
-     *  parameters, pass in NULL for the parameters you want to omit. 
-     * For example, to specify only the database name, username, and 
+     * FileMaker object constructor.
+     *
+     * If you want to use the constructor without specifying all the
+     *  parameters, pass in NULL for the parameters you want to omit.
+     * For example, to specify only the database name, username, and
      * password, but omit the hostspec, call the constructor as follows:
-     *  
+     *
      * <samp>
      * new FileMaker('DatabaseName', NULL, 'username', 'password');
      * </samp>
-     * 
+     *
      * @param string $database Name of the database to connect to.
-     * @param string $hostspec Hostspec of web server in FileMaker Server 
+     * @param string $hostspec Hostspec of web server in FileMaker Server
      *        deployment. Defaults to http://localhost, if set to NULL.
      * @param string $username Account name to log into database.
      * @param string $password Password for account.
      */
-    function FileMaker($database = NULL, $hostspec = NULL, $username = NULL, $password = NULL)
+    public function __construct($database = null, $hostspec = null, $username = null, $password = null)
     {
         $this->_impl = new FileMaker_Implementation($database, $hostspec, $username, $password);
     }
@@ -158,7 +158,7 @@ class FileMaker
      * @param string $prop Name of the property to set.
      * @param string $value Property's new value.
      */
-    function setProperty($prop, $value)
+    public function setProperty($prop, $value)
     {
         $this->_impl->setProperty($prop, $value);
     }
@@ -170,20 +170,20 @@ class FileMaker
      *
      * @return string Property's current value.
      */
-    function getProperty($prop)
+    public function getProperty($prop)
     {
         return $this->_impl->getProperty($prop);
     }
 
     /**
      * Returns an associative array of property name => property value for
-     * all current properties and their current values. 
+     * all current properties and their current values.
      *
      * This array enables PHP object introspection and debugging when necessary.
      *
      * @return array All current properties.
      */
-    function getProperties()
+    public function getProperties()
     {
         return $this->_impl->getProperties();
     }
@@ -194,7 +194,7 @@ class FileMaker
      *
      * @param Log &$logger PEAR Log object.
      */
-    function setLogger(&$logger)
+    public function setLogger(&$logger)
     {
         $this->_impl->setLogger($logger);
     }
@@ -203,14 +203,14 @@ class FileMaker
      * Creates a new FileMaker_Command_Add object.
      *
      * @param string $layout Layout to add a record to.
-     * @param array $values Associative array of field name => value pairs. 
-     *        To set field repetitions, use a numerically indexed array for 
-     *        the value of a field, with the numeric keys corresponding to the 
+     * @param array $values Associative array of field name => value pairs.
+     *        To set field repetitions, use a numerically indexed array for
+     *        the value of a field, with the numeric keys corresponding to the
      *        repetition number to set.
      *
      * @return FileMaker_Command_Add New Add command object.
      */
-    function &newAddCommand($layout, $values = array())
+    public function &newAddCommand($layout, $values = array())
     {
         return $this->_impl->newAddCommand($layout, $values);
     }
@@ -220,15 +220,15 @@ class FileMaker
      *
      * @param string $layout Layout that the record is part of.
      * @param string $recordId ID of the record to edit.
-     * @param array $updatedValues Associative array of field name => value 
-     *        pairs that contain the updated field values. To set field 
-     *        repetitions, use a numerically indexed array for the value of a 
-     *        field, with the numeric keys corresponding to the repetition 
+     * @param array $updatedValues Associative array of field name => value
+     *        pairs that contain the updated field values. To set field
+     *        repetitions, use a numerically indexed array for the value of a
+     *        field, with the numeric keys corresponding to the repetition
      *        number to set.
      *
      * @return FileMaker_Command_Edit New Edit command object.
      */
-    function &newEditCommand($layout, $recordId, $updatedValues = array())
+    public function &newEditCommand($layout, $recordId, $updatedValues = array())
     {
         return $this->_impl->newEditCommand($layout, $recordId, $updatedValues);
     }
@@ -241,7 +241,7 @@ class FileMaker
      *
      * @return FileMaker_Command_Delete New Delete command object.
      */
-    function &newDeleteCommand($layout, $recordId)
+    public function &newDeleteCommand($layout, $recordId)
     {
         return $this->_impl->newDeleteCommand($layout, $recordId);
     }
@@ -254,7 +254,7 @@ class FileMaker
      *
      * @return FileMaker_Command_Duplicate New Duplicate command object.
      */
-    function &newDuplicateCommand($layout, $recordId)
+    public function &newDuplicateCommand($layout, $recordId)
     {
         return $this->_impl->newDuplicateCommand($layout, $recordId);
     }
@@ -266,40 +266,40 @@ class FileMaker
      *
      * @return FileMaker_Command_Find New Find command object.
      */
-    function &newFindCommand($layout)
+    public function &newFindCommand($layout)
     {
         return $this->_impl->newFindCommand($layout);
     }
 
     /**
-     * 
+     *
      * Creates a new FileMaker_Command_CompoundFind object.
      *
      * @param string $layout Layout to find records in.
      *
-     * @return FileMaker_Command_CompoundFind New Compound Find Set command 
+     * @return FileMaker_Command_CompoundFind New Compound Find Set command
      *         object.
      */
-    function &newCompoundFindCommand($layout)
+    public function &newCompoundFindCommand($layout)
     {
         return $this->_impl->newCompoundFindCommand($layout);
     }
-    
-     /**
-     * 
-     * Creates a new FileMaker_Command_FindRequest object. Add one or more 
-     * Find Request objects to a {@link FileMaker_Command_CompoundFind} object, 
+
+    /**
+     *
+     * Creates a new FileMaker_Command_FindRequest object. Add one or more
+     * Find Request objects to a {@link FileMaker_Command_CompoundFind} object,
      * then execute the Compound Find command.
      *
      * @param string $layout Layout to find records in.
      *
      * @return FileMaker_Command_FindRequest New Find Request command object.
      */
-    function &newFindRequest($layout)
+    public function &newFindRequest($layout)
     {
         return $this->_impl->newFindRequest($layout);
     }
-    
+
     /**
      * Creates a new FileMaker_Command_FindAny object.
      *
@@ -307,7 +307,7 @@ class FileMaker
      *
      * @return FileMaker_Command_FindAny New Find Any command object.
      */
-    function &newFindAnyCommand($layout)
+    public function &newFindAnyCommand($layout)
     {
         return $this->_impl->newFindAnyCommand($layout);
     }
@@ -319,7 +319,7 @@ class FileMaker
      *
      * @return FileMaker_Command_FindAll New Find All command object.
      */
-    function &newFindAllCommand($layout)
+    public function &newFindAllCommand($layout)
     {
         return $this->_impl->newFindAllCommand($layout);
     }
@@ -331,30 +331,30 @@ class FileMaker
      * @param string $scriptName Name of the ScriptMaker script to run.
      * @param string $scriptParameters Any parameters to pass to the script.
      *
-     * @return FileMaker_Command_PerformScript New Perform Script command 
+     * @return FileMaker_Command_PerformScript New Perform Script command
      *         object.
      */
-    function &newPerformScriptCommand($layout, $scriptName, $scriptParameters = null)
+    public function &newPerformScriptCommand($layout, $scriptName, $scriptParameters = null)
     {
         return $this->_impl->newPerformScriptCommand($layout, $scriptName, $scriptParameters);
     }
 
     /**
-     * Creates a new FileMaker_Record object. 
-     * 
-     * This method does not save the new record to the database. 
-     * The record is not created on the Database Server until you call 
-     * this record's commit() method. You must specify a layout name, 
-     * and you can optionally specify an array of field values. 
+     * Creates a new FileMaker_Record object.
+     *
+     * This method does not save the new record to the database.
+     * The record is not created on the Database Server until you call
+     * this record's commit() method. You must specify a layout name,
+     * and you can optionally specify an array of field values.
      * Individual field values can also be set in the new record object.
-     * 
+     *
      *
      * @param string $layout Layout to create a new record for.
      * @param array $fieldValues Initial values for the new record's fields.
      *
      * @return FileMaker_Record New Record object.
      */
-    function &createRecord($layout, $fieldValues = array())
+    public function &createRecord($layout, $fieldValues = array())
     {
         return $this->_impl->createRecord($layout, $fieldValues);
     }
@@ -369,7 +369,7 @@ class FileMaker
      *
      * @return FileMaker_Record|FileMaker_Error Record or Error object.
      */
-    function &getRecordById($layout, $recordId)
+    public function &getRecordById($layout, $recordId)
     {
         return $this->_impl->getRecordById($layout, $recordId);
     }
@@ -381,7 +381,7 @@ class FileMaker
      *
      * @return FileMaker_Layout|FileMaker_Error Layout or Error object.
      */
-    function &getLayout($layout)
+    public function &getLayout($layout)
     {
         return $this->_impl->getLayout($layout);
     }
@@ -393,19 +393,19 @@ class FileMaker
      *
      * @return array|FileMaker_Error List of database names or an Error object.
      */
-    function listDatabases()
+    public function listDatabases()
     {
         return $this->_impl->listDatabases();
     }
 
     /**
-     * Returns an array of ScriptMaker scripts from the current database that 
-     * are available with the current server settings and the current user 
+     * Returns an array of ScriptMaker scripts from the current database that
+     * are available with the current server settings and the current user
      * name and password credentials.
      *
      * @return array|FileMaker_Error List of script names or an Error object.
      */
-    function listScripts()
+    public function listScripts()
     {
         return $this->_impl->listScripts();
     }
@@ -417,25 +417,25 @@ class FileMaker
      *
      * @return array|FileMaker_Error List of layout names or an Error object.
      */
-    function listLayouts()
+    public function listLayouts()
     {
         return $this->_impl->listLayouts();
     }
 
     /**
      * Returns the data for the specified container field.
-     * Pass in a URL string that represents the file path for the container 
-     * field contents. For example, get the image data from a container field 
-     * named 'Cover Image'. For a FileMaker_Record object named $record, 
+     * Pass in a URL string that represents the file path for the container
+     * field contents. For example, get the image data from a container field
+     * named 'Cover Image'. For a FileMaker_Record object named $record,
      * URL-encode the path returned by the getField() method.  For example:
-     * 
+     *
      * <samp>
      * <IMG src="img.php?-url=<?php echo urlencode($record->getField('Cover Image')); ?>">
      * </samp>
-     * 
-     * Then as shown below in a line from img.php, pass the URL into 
+     *
+     * Then as shown below in a line from img.php, pass the URL into
      * getContainerData() for the FileMaker object named $fm:
-     * 
+     *
      * <samp>
      * echo $fm->getContainerData($_GET['-url']);
      * </samp>
@@ -444,17 +444,17 @@ class FileMaker
      *
      * @return string Raw field data|FileMaker_Error if remote container field.
      */
-    function getContainerData($url)
+    public function getContainerData($url)
     {
         return $this->_impl->getContainerData($url);
     }
 
     /**
      * Returns the fully qualified URL for the specified container field.
-     * Pass in a URL string that represents the file path for the container 
-     * field contents. For example, get the URL for a container field 
+     * Pass in a URL string that represents the file path for the container
+     * field contents. For example, get the URL for a container field
      * named 'Cover Image'.  For example:
-     * 
+     *
      * <samp>
      * <IMG src="<?php echo $fm->getContainerDataURL($record->getField('Cover Image')); ?>">
      * </samp>
@@ -463,7 +463,7 @@ class FileMaker
      *
      * @return string Fully qualified URL to container field contents
      */
-    function getContainerDataURL($url)
+    public function getContainerDataURL($url)
     {
         return $this->_impl->getContainerDataURL($url);
     }

--- a/src/FMAPI/FileMaker/Command/Add.php
+++ b/src/FMAPI/FileMaker/Command/Add.php
@@ -34,7 +34,7 @@ class FileMaker_Command_Add extends FileMaker_Command
      * @var FileMaker_Command_Add_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Add command constructor.
@@ -46,7 +46,7 @@ class FileMaker_Command_Add extends FileMaker_Command
      * use a numerically indexed array for the value of a field, with the numeric keys
      * corresponding to the repetition number to set.
      */
-    function FileMaker_Command_Add($fm, $layout, $values = array())
+    public function __construct($fm, $layout, $values = array())
     {
         $this->_impl = new FileMaker_Command_Add_Implementation($fm, $layout, $values);
     }
@@ -59,28 +59,28 @@ class FileMaker_Command_Add extends FileMaker_Command
      * @param integer $repetition Field repetition number to set,
      *        Defaults to the first repetition.
      */
-    function setField($field, $value, $repetition = 0)
+    public function setField($field, $value, $repetition = 0)
     {
         return $this->_impl->setField($field, $value, $repetition);
     }
 
     /**
      * Sets the new value for a date, time, or timestamp field from a
-     * UNIX timestamp value. 
+     * UNIX timestamp value.
      *
-     * If the field is not a date or time field, then this method returns  
+     * If the field is not a date or time field, then this method returns
      * an Error object. Otherwise, returns TRUE.
      *
-     * If layout data for the target of this command has not already 
+     * If layout data for the target of this command has not already
      * been loaded, calling this method loads layout data so that
      * the type of the field can be checked.
      *
      * @param string $field Name of the field to set.
      * @param string $timestamp Timestamp value.
-     * @param integer $repetition Field repetition number to set. 
+     * @param integer $repetition Field repetition number to set.
      *        Defaults to the first repetition.
      */
-    function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
+    public function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
     {
         return $this->_impl->setFieldFromTimestamp($field, $timestamp, $repetition);
     }

--- a/src/FMAPI/FileMaker/Command/CompoundFind.php
+++ b/src/FMAPI/FileMaker/Command/CompoundFind.php
@@ -21,9 +21,9 @@ require_once dirname(__FILE__) . '/../Implementation/Command/CompoundFindImpl.ph
 /**#@-*/
 
 /**
- * Command class that performs multiple find requests, also known as a compound 
- * find set. 
- * Requests are executed in the order specified in the add() method. The found 
+ * Command class that performs multiple find requests, also known as a compound
+ * find set.
+ * Requests are executed in the order specified in the add() method. The found
  * set includes the results of the entire compound find request.
  * Create this command with {@link FileMaker::newCompoundFindCommand()}.
  *
@@ -37,48 +37,48 @@ class FileMaker_Command_CompoundFind extends FileMaker_Command
      * @var FileMaker_Command_CompoundFind_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Compound find set constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        request was created by.
      * @param string $layout Layout to find records in.
      */
-    function FileMaker_Command_CompoundFind($fm, $layout)
+    public function __construct($fm, $layout)
     {
         $this->_impl = new FileMaker_Command_CompoundFind_Implementation($fm, $layout);
     }
-  
-     /**
+
+    /**
      * Adds a Find Request object to this Compound Find command.
      *
-     * @param int $precedence Priority in which the find requests are added to 
+     * @param int $precedence Priority in which the find requests are added to
      *        this compound find set.
-     * @param findrequest $findrequest {@link FileMaker_FindRequest} object 
-     *        to add to this compound find set. 
+     * @param findrequest $findrequest {@link FileMaker_FindRequest} object
+     *        to add to this compound find set.
      */
-    function add($precedence, $findrequest)
+    public function add($precedence, $findrequest)
     {
         $this->_impl->add($precedence, $findrequest);
     }
-    
-     /**
+
+    /**
      * Adds a sorting rule to this Compound Find command.
      *
      * @param string $fieldname Name of the field to sort by.
-     * @param integer $precedence Integer from 1 to 9, inclusive. A value  
-     *        of 1 sorts records based on this sorting rule first, a value of 
-     *        2 sorts records based on this sorting rule only when two or more 
-     *        records have the same value after the first sorting rule is 
+     * @param integer $precedence Integer from 1 to 9, inclusive. A value
+     *        of 1 sorts records based on this sorting rule first, a value of
+     *        2 sorts records based on this sorting rule only when two or more
+     *        records have the same value after the first sorting rule is
      *        applied, and so on.
-     * @param mixed $order Direction of the sort. Specify the 
-     *        FILEMAKER_SORT_ASCEND constant, the FILEMAKER_SORT_DESCEND 
+     * @param mixed $order Direction of the sort. Specify the
+     *        FILEMAKER_SORT_ASCEND constant, the FILEMAKER_SORT_DESCEND
      *        constant, or the name of a value list specified as a string.
      */
-    function addSortRule($fieldname, $precedence, $order = null)
+    public function addSortRule($fieldname, $precedence, $order = null)
     {
         $this->_impl->addSortRule($fieldname, $precedence, $order);
     }
@@ -86,19 +86,19 @@ class FileMaker_Command_CompoundFind extends FileMaker_Command
     /**
      * Clears all existing sorting rules from this Compound Find command.
      */
-    function clearSortRules()
+    public function clearSortRules()
     {
         $this->_impl->clearSortRules();
     }
 
-	 /**
+    /**
      * Sets a range to request only part of the result set.
      *
      * @param integer $skip Number of records to skip past. Default is 0.
-     * @param integer $max Maximum number of records to return. 
+     * @param integer $max Maximum number of records to return.
      *        Default is all.
      */
-    function setRange($skip = 0, $max = null)
+    public function setRange($skip = 0, $max = null)
     {
         $this->_impl->setRange($skip, $max);
     }
@@ -108,42 +108,42 @@ class FileMaker_Command_CompoundFind extends FileMaker_Command
      *
      * @return array Associative array with two keys: 'skip' for
      * the current skip setting, and 'max' for the current maximum
-     * number of records. If either key does not have a value, the 
+     * number of records. If either key does not have a value, the
      * returned value for that key is NULL.
      */
-    function getRange()
+    public function getRange()
     {
         return $this->_impl->getRange();
     }
-    
+
     /**
-     * Sets a filter to restrict the number of related records to return from 
-     * a portal. 
+     * Sets a filter to restrict the number of related records to return from
+     * a portal.
      *
-     * For more information, see the description for the 
+     * For more information, see the description for the
      * {@link FileMaker_Command_Find::setRelatedSetsFilters()} method.
      *
-     * @param string $relatedsetsfilter Specify either 'layout' or 'none' to 
-     *        control filtering.  
-     * @param string $relatedsetsmax Maximum number of portal records 
+     * @param string $relatedsetsfilter Specify either 'layout' or 'none' to
+     *        control filtering.
+     * @param string $relatedsetsmax Maximum number of portal records
      *        to return.
      */
-    function setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax = null)
+    public function setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax = null)
     {
-    	return $this->_impl->setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax);
+        return $this->_impl->setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax);
     }
-    
+
     /**
-     * Returns the current settings for the related records filter and  
+     * Returns the current settings for the related records filter and
      * the maximum number of related records to return.
      *
      * @return array Associative array with two keys: 'relatedsetsfilter' for
      * the portal filter setting, and 'relatedsetsmax' for the maximum
-     * number of records. If either key does not have a value, the returned 
+     * number of records. If either key does not have a value, the returned
      * for that key is NULL.
      */
-    function getRelatedSetsFilters()
+    public function getRelatedSetsFilters()
     {
-    	return $this->_impl->getRelatedSetsFilters();
+        return $this->_impl->getRelatedSetsFilters();
     }
 }

--- a/src/FMAPI/FileMaker/Command/Delete.php
+++ b/src/FMAPI/FileMaker/Command/Delete.php
@@ -34,18 +34,18 @@ class FileMaker_Command_Delete extends FileMaker_Command
      * @var FileMaker_Command_Delete_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Delete command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout to delete record from.
      * @param string $recordId ID of the record to delete.
      */
-    function FileMaker_Command_Delete($fm, $layout, $recordId)
+    public function __construct($fm, $layout, $recordId)
     {
         $this->_impl = new FileMaker_Command_Delete_Implementation($fm, $layout, $recordId);
     }

--- a/src/FMAPI/FileMaker/Command/Duplicate.php
+++ b/src/FMAPI/FileMaker/Command/Duplicate.php
@@ -34,18 +34,18 @@ class FileMaker_Command_Duplicate extends FileMaker_Command
      * @var FileMaker_Command_Duplicate_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Duplicate command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout the record to duplicate is in.
      * @param string $recordId ID of the record to duplicate.
      */
-    function FileMaker_Command_Duplicate($fm, $layout, $recordId)
+    public function __construct($fm, $layout, $recordId)
     {
         $this->_impl = new FileMaker_Command_Duplicate_Implementation($fm, $layout, $recordId);
     }

--- a/src/FMAPI/FileMaker/Command/Edit.php
+++ b/src/FMAPI/FileMaker/Command/Edit.php
@@ -34,22 +34,22 @@ class FileMaker_Command_Edit extends FileMaker_Command
      * @var FileMaker_Command_Edit_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Edit command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout the record is part of.
      * @param string $recordId ID of the record to edit.
-     * @param array $values Associative array of field name => value pairs. 
-     *        To set field repetitions, use a numerically indexed array for 
-     *        the value of a field, with the numeric keys corresponding to the 
+     * @param array $values Associative array of field name => value pairs.
+     *        To set field repetitions, use a numerically indexed array for
+     *        the value of a field, with the numeric keys corresponding to the
      *        repetition number to set.
      */
-    function FileMaker_Command_Edit($fm, $layout, $recordId, $updatedValues = array())
+    public function __construct($fm, $layout, $recordId, $updatedValues = array())
     {
         $this->_impl = new FileMaker_Command_Edit_Implementation($fm, $layout, $recordId, $updatedValues);
     }
@@ -62,28 +62,28 @@ class FileMaker_Command_Edit extends FileMaker_Command
      * @param integer $repetition Field repetition number to set,
      *        Defaults to the first repetition.
      */
-    function setField($field, $value, $repetition = 0)
+    public function setField($field, $value, $repetition = 0)
     {
         return $this->_impl->setField($field, $value, $repetition);
     }
 
     /**
      * Sets the new value for a date, time, or timestamp field from a
-     * UNIX timestamp value. 
+     * UNIX timestamp value.
      *
-     * If the field is not a date or time field, then this method returns 
+     * If the field is not a date or time field, then this method returns
      * an Error object. Otherwise, returns TRUE.
      *
-     * If layout data for the target of this command has not already 
+     * If layout data for the target of this command has not already
      * been loaded, calling this method loads layout data so that
      * the type of the field can be checked.
      *
      * @param string $field Name of the field to set.
      * @param string $timestamp Timestamp value.
-     * @param integer $repetition Field repetition number to set. 
+     * @param integer $repetition Field repetition number to set.
      *        Defaults to the first repetition.
      */
-    function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
+    public function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
     {
         return $this->_impl->setFieldFromTimestamp($field, $timestamp, $repetition);
     }
@@ -91,17 +91,17 @@ class FileMaker_Command_Edit extends FileMaker_Command
     /**
      * Sets the modification ID for this command.
      *
-     * Before you edit a record, you can use the 
-     * {@link FileMaker_Record::getModificationId()} method to get the record's 
-     * modification ID. By specifying a modification ID when you execute an 
-     * Edit command, you can make sure that you are editing the current version 
-     * of a record. If the modification ID value you specify does not match the 
-     * current modification ID value in the database, the Edit command is not 
-     * allowed and an error code is returned. 
-     * 
+     * Before you edit a record, you can use the
+     * {@link FileMaker_Record::getModificationId()} method to get the record's
+     * modification ID. By specifying a modification ID when you execute an
+     * Edit command, you can make sure that you are editing the current version
+     * of a record. If the modification ID value you specify does not match the
+     * current modification ID value in the database, the Edit command is not
+     * allowed and an error code is returned.
+     *
      * @param integer $modificationId Modification ID.
      */
-    function setModificationId($modificationId)
+    public function setModificationId($modificationId)
     {
         $this->_impl->setModificationId($modificationId);
     }

--- a/src/FMAPI/FileMaker/Command/Find.php
+++ b/src/FMAPI/FileMaker/Command/Find.php
@@ -34,17 +34,17 @@ class FileMaker_Command_Find extends FileMaker_Command
      * @var FileMaker_Command_Find_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Find command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout to find records in.
      */
-    function FileMaker_Command_Find($fm, $layout)
+    public function __construct($fm, $layout)
     {
         $this->_impl = new FileMaker_Command_Find_Implementation($fm, $layout);
     }
@@ -55,7 +55,7 @@ class FileMaker_Command_Find extends FileMaker_Command
      * @param string $fieldname Name of the field being tested.
      * @param string $testvalue Value of field to test against.
      */
-    function addFindCriterion($fieldname, $testvalue)
+    public function addFindCriterion($fieldname, $testvalue)
     {
         $this->_impl->addFindCriterion($fieldname, $testvalue);
     }
@@ -63,7 +63,7 @@ class FileMaker_Command_Find extends FileMaker_Command
     /**
      * Clears all existing criteria from this Find command.
      */
-    function clearFindCriteria()
+    public function clearFindCriteria()
     {
         $this->_impl->clearFindCriteria();
     }
@@ -72,16 +72,16 @@ class FileMaker_Command_Find extends FileMaker_Command
      * Adds a sorting rule to this Find command.
      *
      * @param string $fieldname Name of the field to sort by.
-     * @param integer $precedence Integer from 1 to 9, inclusive. A value 
-     *        of 1 sorts records based on this sorting rule first, a value of 
-     *        2 sorts records based on this sorting rule only when two or more 
-     *        records have the same value after the first sorting rule is 
+     * @param integer $precedence Integer from 1 to 9, inclusive. A value
+     *        of 1 sorts records based on this sorting rule first, a value of
+     *        2 sorts records based on this sorting rule only when two or more
+     *        records have the same value after the first sorting rule is
      *        applied, and so on.
-     * @param mixed $order Direction of the sort. Specify the 
-     *        FILEMAKER_SORT_ASCEND constant, the FILEMAKER_SORT_DESCEND 
+     * @param mixed $order Direction of the sort. Specify the
+     *        FILEMAKER_SORT_ASCEND constant, the FILEMAKER_SORT_DESCEND
      *        constant, or the name of a value list specified as a string.
      */
-    function addSortRule($fieldname, $precedence, $order = null)
+    public function addSortRule($fieldname, $precedence, $order = null)
     {
         $this->_impl->addSortRule($fieldname, $precedence, $order);
     }
@@ -89,21 +89,21 @@ class FileMaker_Command_Find extends FileMaker_Command
     /**
      * Clears all existing sorting rules from this Find command.
      */
-    function clearSortRules()
+    public function clearSortRules()
     {
         $this->_impl->clearSortRules();
     }
 
     /**
-     * Specifies how the find criteria in this Find command are combined 
-     * as either a logical AND or OR search. 
+     * Specifies how the find criteria in this Find command are combined
+     * as either a logical AND or OR search.
      *
      * If not specified, the default is a logical AND.
      *
-     * @param integer $operator Specify the FILEMAKER_FIND_AND or 
+     * @param integer $operator Specify the FILEMAKER_FIND_AND or
      *        FILEMAKER_FIND_OR constant.
      */
-    function setLogicalOperator($operator)
+    public function setLogicalOperator($operator)
     {
         $this->_impl->setLogicalOperator($operator);
     }
@@ -112,10 +112,10 @@ class FileMaker_Command_Find extends FileMaker_Command
      * Sets a range to request only part of the result set.
      *
      * @param integer $skip Number of records to skip past. Default is 0.
-     * @param integer $max Maximum number of records to return. 
+     * @param integer $max Maximum number of records to return.
      *        Default is all.
      */
-    function setRange($skip = 0, $max = null)
+    public function setRange($skip = 0, $max = null)
     {
         $this->_impl->setRange($skip, $max);
     }
@@ -125,58 +125,58 @@ class FileMaker_Command_Find extends FileMaker_Command
      *
      * @return array Associative array with two keys: 'skip' for
      * the current skip setting, and 'max' for the current maximum
-     * number of records. If either key does not have a value, the 
+     * number of records. If either key does not have a value, the
      * returned value for that key is NULL.
      */
-    function getRange()
+    public function getRange()
     {
         return $this->_impl->getRange();
     }
-    
+
     /**
-     * Sets a filter to restrict the number of related records to return from 
-     * a portal. 
+     * Sets a filter to restrict the number of related records to return from
+     * a portal.
      *
-     * The filter limits the number of related records returned by respecting 
-     * the settings specified in the FileMaker Pro Portal Setup dialog box. 
+     * The filter limits the number of related records returned by respecting
+     * the settings specified in the FileMaker Pro Portal Setup dialog box.
      *
-     * @param string $relatedsetsfilter Specify one of these values to  
-     *        control filtering: 
-     *        - 'layout': Apply the settings specified in the FileMaker Pro 
-     *                    Portal Setup dialog box. The records are sorted based 
-     *                    on the sort  defined in the Portal Setup dialog box, 
-     *                    with the record set filtered to start with the 
+     * @param string $relatedsetsfilter Specify one of these values to
+     *        control filtering:
+     *        - 'layout': Apply the settings specified in the FileMaker Pro
+     *                    Portal Setup dialog box. The records are sorted based
+     *                    on the sort  defined in the Portal Setup dialog box,
+     *                    with the record set filtered to start with the
      *                    specified "Initial row."
-     *        - 'none': Return all related records in the portal without 
+     *        - 'none': Return all related records in the portal without
      *                  filtering or presorting them.
-     * 
-     * @param string $relatedsetsmax If the "Show vertical scroll bar" setting 
-     *        is enabled in the Portal Setup dialog box, specify one of these 
+     *
+     * @param string $relatedsetsmax If the "Show vertical scroll bar" setting
+     *        is enabled in the Portal Setup dialog box, specify one of these
      *        values:
-     *        - an integer value: Return this maximum number of related records 
+     *        - an integer value: Return this maximum number of related records
      *                            after the initial record.
      *        - 'all': Return all of the related records in the portal.
-     *                 If "Show vertical scroll bar" is disabled, the Portal 
-     *                 Setup dialog box's "Number of rows" setting determines 
-     *                 the maximum number of related records to return. 
+     *                 If "Show vertical scroll bar" is disabled, the Portal
+     *                 Setup dialog box's "Number of rows" setting determines
+     *                 the maximum number of related records to return.
      */
-    function setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax = null)
+    public function setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax = null)
     {
-    	return $this->_impl->setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax);
+        return $this->_impl->setRelatedSetsFilters($relatedsetsfilter, $relatedsetsmax);
     }
-    
+
     /**
-     * Returns the current settings for the related records filter and  
+     * Returns the current settings for the related records filter and
      * the maximum number of related records to return.
      *
-     * @return array Associative array with two keys: 'relatedsetsfilter' for 
-     * the portal filter setting, and 'relatedsetsmax' for the maximum 
-     * number of records. If either key does not have a value, the returned 
+     * @return array Associative array with two keys: 'relatedsetsfilter' for
+     * the portal filter setting, and 'relatedsetsmax' for the maximum
+     * number of records. If either key does not have a value, the returned
      * for that key is NULL.
      */
-    function getRelatedSetsFilters()
+    public function getRelatedSetsFilters()
     {
-    	return $this->_impl->getRelatedSetsFilters();
+        return $this->_impl->getRelatedSetsFilters();
     }
 
 }

--- a/src/FMAPI/FileMaker/Command/FindAll.php
+++ b/src/FMAPI/FileMaker/Command/FindAll.php
@@ -21,7 +21,7 @@ require_once dirname(__FILE__) . '/../Implementation/Command/FindAllImpl.php';
 /**#@-*/
 
 /**
- * Command class that finds all records from a layout. 
+ * Command class that finds all records from a layout.
  * Create this command with {@link FileMaker::newFindAllCommand()}.
  *
  * @package FileMaker
@@ -34,17 +34,17 @@ class FileMaker_Command_FindAll extends FileMaker_Command_Find
      * @var FileMaker_Command_FindAll_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * FindAll command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout to find all records in.
      */
-    function FileMaker_Command_FindAll($fm, $layout)
+    public function __construct($fm, $layout)
     {
         $this->_impl = new FileMaker_Command_FindAll_Implementation($fm, $layout);
     }

--- a/src/FMAPI/FileMaker/Command/FindAny.php
+++ b/src/FMAPI/FileMaker/Command/FindAny.php
@@ -34,17 +34,17 @@ class FileMaker_Command_FindAny extends FileMaker_Command_Find
      * @var FileMaker_Command_FindAny_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * FindAny command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout to find a random record from.
      */
-    function FileMaker_Command_FindAny($fm, $layout)
+    public function __construct($fm, $layout)
     {
         $this->_impl = new FileMaker_Command_FindAny_Implementation($fm, $layout);
     }

--- a/src/FMAPI/FileMaker/Command/FindRequest.php
+++ b/src/FMAPI/FileMaker/Command/FindRequest.php
@@ -21,7 +21,7 @@ require_once dirname(__FILE__) . '/../Implementation/Command/FindRequestImpl.php
 /**#@-*/
 
 /**
- * Find Request class. Contains all the information about a single find request 
+ * Find Request class. Contains all the information about a single find request
  * for a Compound Find command.
  * Create this command with {@link FileMaker::newFindRequest()}.
  *
@@ -35,29 +35,29 @@ class FileMaker_Command_FindRequest
      * @var FileMaker_Command_Find_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Find request constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        request was created by.
      * @param string $layout Layout to find records in.
      */
-    function FileMaker_Command_FindRequest($fm, $layout)
+    public function __construct($fm, $layout)
     {
         $this->_impl = new FileMaker_Command_FindRequest_Implementation($fm, $layout);
     }
 
     /**
      * Sets whether this request is an omit request.
-     * 
+     *
      * An omit request removes the matching records from the final result set.
      *
      * @param boolean $value TRUE if this is an omit request. Otherwise, FALSE.
      */
-    function setOmit($value)
+    public function setOmit($value)
     {
         $this->_impl->setOmit($value);
     }
@@ -68,18 +68,17 @@ class FileMaker_Command_FindRequest
      * @param string $fieldname Name of the field being tested.
      * @param string $testvalue Value of the field to test against.
      */
-    function addFindCriterion($fieldname, $testvalue)
+    public function addFindCriterion($fieldname, $testvalue)
     {
         $this->_impl->addFindCriterion($fieldname, $testvalue);
     }
-    
+
     /**
      * Clears all existing criteria from this find request.
      */
-    function clearFindCriteria()
+    public function clearFindCriteria()
     {
         $this->_impl->clearFindCriteria();
     }
 
-	   
 }

--- a/src/FMAPI/FileMaker/Command/PerformScript.php
+++ b/src/FMAPI/FileMaker/Command/PerformScript.php
@@ -34,19 +34,19 @@ class FileMaker_Command_PerformScript extends FileMaker_Command
      * @var FileMaker_Command_PerformScript_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * PerformScript command constructor.
      *
      * @ignore
-     * @param FileMaker_Implementation $fm FileMaker_Implementation object the 
+     * @param FileMaker_Implementation $fm FileMaker_Implementation object the
      *        command was created by.
      * @param string $layout Layout to use for script context.
      * @param string $scriptName Name of the script to run.
      * @param string $scriptParameters Any parameters to pass to the script.
      */
-    function FileMaker_Command_PerformScript($fm, $layout, $scriptName, $scriptParameters = null)
+    public function __construct($fm, $layout, $scriptName, $scriptParameters = null)
     {
         $this->_impl = new FileMaker_Command_PerformScript_Implementation($fm, $layout, $scriptName, $scriptParameters);
     }

--- a/src/FMAPI/FileMaker/Error.php
+++ b/src/FMAPI/FileMaker/Error.php
@@ -36,19 +36,19 @@ class FileMaker_Error extends PEAR_Error
      * @var FileMaker
      * @access private
      */
-    var $_fm;
+    public $_fm;
 
     /**
      * Overloaded FileMaker_Error constructor.
      *
-     * @param FileMaker_Delegate &$fm FileMaker_Delegate object this error 
+     * @param FileMaker_Delegate &$fm FileMaker_Delegate object this error
      *        came from.
      * @param string $message Error message.
      * @param integer $code Error code.
      */
-    function FileMaker_Error(&$fm, $message = null, $code = null)
+    public function __construct(&$fm, $message = null, $code = null)
     {
-        $this->_fm =& $fm;
+        $this->_fm = &$fm;
         parent::PEAR_Error($message, $code);
 
         // Log the error.
@@ -56,13 +56,13 @@ class FileMaker_Error extends PEAR_Error
     }
 
     /**
-     * Overloads getMessage() to return an equivalent FileMaker Web Publishing 
-     * Engine error if no message is explicitly set and this object has an 
+     * Overloads getMessage() to return an equivalent FileMaker Web Publishing
+     * Engine error if no message is explicitly set and this object has an
      * error code.
-     * 
+     *
      * @return string Error message.
      */
-    function getMessage()
+    public function getMessage()
     {
         if ($this->message === null && $this->getCode() !== null) {
             return $this->getErrorString();
@@ -71,16 +71,16 @@ class FileMaker_Error extends PEAR_Error
     }
 
     /**
-     * Returns the string representation of $this->code in the language 
-     * currently  set for PHP error messages in FileMaker Server Admin 
+     * Returns the string representation of $this->code in the language
+     * currently  set for PHP error messages in FileMaker Server Admin
      * Console.
-     * 
+     *
      * You should call getMessage() in most cases, if you are not sure whether
      * the error is a FileMaker Web Publishing Engine error with an error code.
      *
      * @return string Error description.
      */
-    function getErrorString()
+    public function getErrorString()
     {
         // Default to English.
         $lang = basename($this->_fm->getProperty('locale'));
@@ -104,13 +104,13 @@ class FileMaker_Error extends PEAR_Error
     }
 
     /**
-     * Indicates whether the error is a detailed pre-validation error  
+     * Indicates whether the error is a detailed pre-validation error
      * or a FileMaker Web Publishing Engine error.
      *
-     * @return boolean FALSE, to indicate that this is an error from the 
+     * @return boolean FALSE, to indicate that this is an error from the
      *         Web Publishing Engine.
      */
-    function isValidationError()
+    public function isValidationError()
     {
         return false;
     }

--- a/src/FMAPI/FileMaker/Field.php
+++ b/src/FMAPI/FileMaker/Field.php
@@ -34,14 +34,14 @@ class FileMaker_Field
      * @var FileMaker_Layout_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Field object constructor.
      *
      * @param FileMaker_Layout &$layout Parent Layout object.
      */
-    function FileMaker_Field(&$layout)
+    public function __construct(&$layout)
     {
         $this->_impl = new FileMaker_Field_Implementation($layout);
     }
@@ -51,7 +51,7 @@ class FileMaker_Field
      *
      * @return string Field name.
      */
-    function getName()
+    public function getName()
     {
         return $this->_impl->getName();
     }
@@ -61,18 +61,18 @@ class FileMaker_Field
      *
      * @return FileMaker_Layout Layout object.
      */
-    function &getLayout()
+    public function &getLayout()
     {
-        return $layout =& $this->_impl->getLayout();
+        return $layout = &$this->_impl->getLayout();
     }
 
     /**
-     * Returns TRUE if data in this field is auto-entered or FALSE 
+     * Returns TRUE if data in this field is auto-entered or FALSE
      * if it is entered manually.
      *
      * @return boolean Auto-entered status of this field.
      */
-    function isAutoEntered()
+    public function isAutoEntered()
     {
         return $this->_impl->isAutoEntered();
     }
@@ -82,7 +82,7 @@ class FileMaker_Field
      *
      * @return boolean Global status of this field.
      */
-    function isGlobal()
+    public function isGlobal()
     {
         return $this->_impl->isGlobal();
     }
@@ -92,7 +92,7 @@ class FileMaker_Field
      *
      * @return integer Maximum repetitions of this field.
      */
-    function getRepetitionCount()
+    public function getRepetitionCount()
     {
         return $this->_impl->getRepetitionCount();
     }
@@ -103,42 +103,42 @@ class FileMaker_Field
      * failed.
      *
      * @param mixed $value Value to pre-validate.
-     * @param FileMaker_Error_Validation $error If pre-validation is being 
-     *        done on more than one field, you may pass validate() an existing 
-     *        error object to add pre-validation failures to.$error is not 
-     *        passed by reference, though, so you must catch the return value 
-     *        of validate() and use it as the new $error object. This method 
+     * @param FileMaker_Error_Validation $error If pre-validation is being
+     *        done on more than one field, you may pass validate() an existing
+     *        error object to add pre-validation failures to.$error is not
+     *        passed by reference, though, so you must catch the return value
+     *        of validate() and use it as the new $error object. This method
      *        never overwrites an existing $error object with boolean TRUE.
      *
-     * @return boolean|FileMaker_Error_Validation Result of field 
+     * @return boolean|FileMaker_Error_Validation Result of field
      *         pre-validation on $value.
      */
-    function validate($value, $error = null)
+    public function validate($value, $error = null)
     {
         return $this->_impl->validate($value, $error);
     }
 
     /**
-     * Returns an array of FILEMAKER_RULE_* constants for each rule 
-     * set on this field that can be evaluated by the PHP engine. 
-     * 
-     * Rules such as "unique" and "exists" can only be pre-validated on the 
+     * Returns an array of FILEMAKER_RULE_* constants for each rule
+     * set on this field that can be evaluated by the PHP engine.
+     *
+     * Rules such as "unique" and "exists" can only be pre-validated on the
      * Database Server and are not included in this list.
      *
      * @return array Local rule array.
      */
-    function getLocalValidationRules()
+    public function getLocalValidationRules()
     {
         return $this->_impl->getLocalValidationRules();
     }
 
     /**
-     * Returns an array of FILEMAKER_RULE_* constants for each rule 
+     * Returns an array of FILEMAKER_RULE_* constants for each rule
      * set on this field.
      *
      * @return array Rule array.
      */
-    function getValidationRules()
+    public function getValidationRules()
     {
         return $this->_impl->getValidationRules();
     }
@@ -149,7 +149,7 @@ class FileMaker_Field
      *
      * @return integer Rule bitmask.
      */
-    function getValidationMask()
+    public function getValidationMask()
     {
         return $this->_impl->getValidationMask();
     }
@@ -162,43 +162,43 @@ class FileMaker_Field
      *
      * @return boolean
      */
-    function hasValidationRule($validationRule)
+    public function hasValidationRule($validationRule)
     {
         return $this->_impl->hasValidationRule($validationRule);
     }
 
     /**
-     * Returns any additional information for the specified pre-validation 
-     * rule. 
+     * Returns any additional information for the specified pre-validation
+     * rule.
      *
-     * Used for range rules and other rules that have additional 
+     * Used for range rules and other rules that have additional
      * pre-validation parameters.
      *
-     * @param integer $validationRule FILEMAKER_RULE_* constant 
-     *        to get information for. 
-     * 
+     * @param integer $validationRule FILEMAKER_RULE_* constant
+     *        to get information for.
+     *
      * @return array Any extra information for $validationRule.
      */
-    function describeValidationRule($validationRule)
+    public function describeValidationRule($validationRule)
     {
         return $this->_impl->describeValidationRule($validationRule);
     }
 
     /**
-     * Return an array of arrays containing the extra information for 
-     * all pre-validation rules on this field that can be evaluated by the 
-     * PHP engine. 
-     * 
-     * Rules such as "unique" and "exists" can be validated only 
-     * on the Database Server and are not included in this list. 
-     * Indexes of the outer array are FILEMAKER_RULE_* constants, 
+     * Return an array of arrays containing the extra information for
+     * all pre-validation rules on this field that can be evaluated by the
+     * PHP engine.
+     *
+     * Rules such as "unique" and "exists" can be validated only
+     * on the Database Server and are not included in this list.
+     * Indexes of the outer array are FILEMAKER_RULE_* constants,
      * and values are the same array returned by describeValidationRule().
      *
-     * @return array An associative array of all extra pre-validation 
-     *         information, with rule constants as indexes and extra 
+     * @return array An associative array of all extra pre-validation
+     *         information, with rule constants as indexes and extra
      *         information as the values.
      */
-    function describeLocalValidationRules()
+    public function describeLocalValidationRules()
     {
         return $this->_impl->describeLocalValidationRules();
     }
@@ -206,11 +206,11 @@ class FileMaker_Field
     /**
      * Returns any additional information for all pre-validation rules.
      *
-     * @return array An associative array of all extra pre-validation 
-     *         information, with FILEMAKER_RULE_* constants 
+     * @return array An associative array of all extra pre-validation
+     *         information, with FILEMAKER_RULE_* constants
      *         as keys and extra information as the values.
      */
-    function describeValidationRules()
+    public function describeValidationRules()
     {
         return $this->_impl->describeValidationRules();
     }
@@ -221,7 +221,7 @@ class FileMaker_Field
      *
      * @return string Result type.
      */
-    function getResult()
+    public function getResult()
     {
         return $this->_impl->getResult();
     }
@@ -232,35 +232,35 @@ class FileMaker_Field
      *
      * @return string Type.
      */
-    function getType()
+    public function getType()
     {
         return $this->_impl->getType();
     }
 
     /**
-     * Returns the list of choices from the value list associated with this 
-     * field. 
+     * Returns the list of choices from the value list associated with this
+     * field.
      *
-     * If this field is not associated with a value list, this method returns 
+     * If this field is not associated with a value list, this method returns
      * NULL.
      *
      * @param string  $recid Record from which to display the value list.
-     * 
+     *
      * @return array Value list array.
      */
-    function getValueList($recid = null)
+    public function getValueList($recid = null)
     {
         return $this->_impl->getValueList($recid);
     }
 
     /**
-     * Returns the control style type of this field -- for example, 
+     * Returns the control style type of this field -- for example,
      * 'EDITTEXT', 'POPUPLIST', 'POPUPMENU', 'CHECKBOX', 'RADIOBUTTONS' or
      * 'CALENDAR'.
      *
      * @return string Style type.
      */
-    function getStyleType()
+    public function getStyleType()
     {
         return $this->_impl->getStyleType();
     }

--- a/src/FMAPI/FileMaker/Implementation/Command/AddImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/AddImpl.php
@@ -1,81 +1,81 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_Add_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_Add_Implementation extends FileMaker_Command_Implementation
 {
-  var $_fields = array();
- function FileMaker_Command_Add_Implementation($V0ab34ca9, $Vc6140495, $Vf09cc7ee = array())
- { 
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-foreach ($Vf09cc7ee as $V06e3d36f => $V2063c160) {
- if (!is_array($V2063c160)) {
- $V2063c160 = array($V2063c160);
-}
-$this->_fields[$V06e3d36f] = $V2063c160;
-}
-}
- function &execute()
- {  
- if ($this->_fm->getProperty('prevalidate')) {
- $V9f7d0ee8 = $this->validate();
-if (FileMaker::isError($V9f7d0ee8)) {
- return $V9f7d0ee8;
-}
-} 
- $Vc6140495 =& $this->_fm->getLayout($this->_layout);
-if (FileMaker::isError($Vc6140495)) {
- return $Vc6140495;
-} 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-new'] = true; 
- foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
- if (strpos($V972bf3f0, '.') !== false) {
- list($Vb068931c, $V11e868ac) = explode('.', $V972bf3f0, 2);
-$V11e868ac = '.' . $V11e868ac;
-} else {
- $Vb068931c = $V972bf3f0;
-$V06e3d36f = $Vc6140495->getField($V972bf3f0);
-if (FileMaker::isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-if ($V06e3d36f->isGlobal()) {
- $V11e868ac = '.global';
-} else {
- $V11e868ac = '';
-}
-}
-foreach ($Vee0525e4 as $V6a992d55 => $V3a6d0284) {
- $V21ffce5b[$Vb068931c . '(' . ($V6a992d55 + 1) . ')' . $V11e868ac] = $V3a6d0284;
-}
-} 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
- function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0)
- {
- $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
-return $V2063c160;
-}
- function setFieldFromTimestamp($V972bf3f0, $Vd7e6d55b, $V6d786dc7 = 0)
- {
- $Vc6140495 =& $this->_fm->getLayout($this->_layout);
-if (FileMaker::isError($Vc6140495)) {
- return $Vc6140495;
-}
-$V06e3d36f = $Vc6140495->getField($V972bf3f0);
-if (FileMaker::isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-switch ($V06e3d36f->getResult()) {
- case 'date':
- return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
-case 'time':
- return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
-case 'timestamp':
- return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
-}
-return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
-}
+    public $_fields = array();
+    public function __construct($V0ab34ca9, $Vc6140495, $Vf09cc7ee = array())
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        foreach ($Vf09cc7ee as $V06e3d36f => $V2063c160) {
+            if (!is_array($V2063c160)) {
+                $V2063c160 = array($V2063c160);
+            }
+            $this->_fields[$V06e3d36f] = $V2063c160;
+        }
+    }
+    public function &execute()
+    {
+        if ($this->_fm->getProperty('prevalidate')) {
+            $V9f7d0ee8 = $this->validate();
+            if (FileMaker::isError($V9f7d0ee8)) {
+                return $V9f7d0ee8;
+            }
+        }
+        $Vc6140495 = &$this->_fm->getLayout($this->_layout);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-new'] = true;
+        foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
+            if (strpos($V972bf3f0, '.') !== false) {
+                list($Vb068931c, $V11e868ac) = explode('.', $V972bf3f0, 2);
+                $V11e868ac = '.' . $V11e868ac;
+            } else {
+                $Vb068931c = $V972bf3f0;
+                $V06e3d36f = $Vc6140495->getField($V972bf3f0);
+                if (FileMaker::isError($V06e3d36f)) {
+                    return $V06e3d36f;
+                }
+                if ($V06e3d36f->isGlobal()) {
+                    $V11e868ac = '.global';
+                } else {
+                    $V11e868ac = '';
+                }
+            }
+            foreach ($Vee0525e4 as $V6a992d55 => $V3a6d0284) {
+                $V21ffce5b[$Vb068931c . '(' . ($V6a992d55 + 1) . ')' . $V11e868ac] = $V3a6d0284;
+            }
+        }
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
+    public function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0)
+    {
+        $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
+        return $V2063c160;
+    }
+    public function setFieldFromTimestamp($V972bf3f0, $Vd7e6d55b, $V6d786dc7 = 0)
+    {
+        $Vc6140495 = &$this->_fm->getLayout($this->_layout);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $V06e3d36f = $Vc6140495->getField($V972bf3f0);
+        if (FileMaker::isError($V06e3d36f)) {
+            return $V06e3d36f;
+        }
+        switch ($V06e3d36f->getResult()) {
+            case 'date':
+                return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
+            case 'time':
+                return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
+            case 'timestamp':
+                return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
+        }
+        return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/CompoundFindImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/CompoundFindImpl.php
@@ -1,133 +1,132 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_CompoundFind_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_CompoundFind_Implementation extends FileMaker_Command_Implementation
 {
-	 var $_findCriteria = array();
- var $Vd65662c5 = array();
- var $Va9136a07 = array();
- var $V83f28691;
- var $V85fd701e;
- var $V6da136ea;
- var $V568aa2ec;
- var $Vad2bfd5a = array();
- function FileMaker_Command_CompoundFind_Implementation($V0ab34ca9, $Vc6140495)
-	{
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-}
- function &execute()
-	{ 
- $V090cbceb= null;
+    public $_findCriteria = array();
+    public $Vd65662c5 = array();
+    public $Va9136a07 = array();
+    public $V83f28691;
+    public $V85fd701e;
+    public $V6da136ea;
+    public $V568aa2ec;
+    public $Vad2bfd5a = array();
+    public function __construct($V0ab34ca9, $Vc6140495)
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+    }
+    public function &execute()
+    {
+        $V090cbceb = null;
 
- $V8ac10dab = 0; 
- $V31c3c8cf = 0;
-$V40677621 = 1; 
- $Ve2942a04 = 1; 
- $V21ffce5b = $this->_getCommandParams(); 
- $this->_setSortParams($V21ffce5b);
-$this->_setRangeParams($V21ffce5b);
-$this->_setRelatedSetsFilters($V21ffce5b); 
- ksort($this->Vad2bfd5a); 
- $V31c3c8cf=count($this->Vad2bfd5a);  
- foreach ($this->Vad2bfd5a as $V70a17ffa =>	$V9a7aa128)
- {  
- $V15c46c6e = $V9a7aa128->_impl->_findCriteria;
-$V8ac10dab = count($V15c46c6e);
+        $V8ac10dab = 0;
+        $V31c3c8cf = 0;
+        $V40677621 = 1;
+        $Ve2942a04 = 1;
+        $V21ffce5b = $this->_getCommandParams();
+        $this->_setSortParams($V21ffce5b);
+        $this->_setRangeParams($V21ffce5b);
+        $this->_setRelatedSetsFilters($V21ffce5b);
+        ksort($this->Vad2bfd5a);
+        $V31c3c8cf = count($this->Vad2bfd5a);
+        foreach ($this->Vad2bfd5a as $V70a17ffa => $V9a7aa128) {
+            $V15c46c6e = $V9a7aa128->_impl->_findCriteria;
+            $V8ac10dab = count($V15c46c6e);
 
- $V090cbceb = $V090cbceb.'(';
+            $V090cbceb = $V090cbceb . '(';
 
- $V4111477f = 0;
-foreach ($V15c46c6e as $Vd1148ee8 => $Ve9de89b0) { 
- $V21ffce5b['-q'.$Ve2942a04] = $Vd1148ee8;
-$V21ffce5b['-q'.$Ve2942a04.'.'."value"] = $Ve9de89b0; 
- $V090cbceb=$V090cbceb.'q'.$Ve2942a04; 
- $Ve2942a04++;
-$V4111477f++; 
- 
- if($V4111477f < $V8ac10dab){
- $V090cbceb = $V090cbceb.',';
-}
-}
-$V090cbceb=$V090cbceb.")"; 
- $V40677621++; 
- if($V40677621 <= $V31c3c8cf){ 
- $V4b22ce92 = $this->Vad2bfd5a[$V40677621];
-if($V4b22ce92->_impl->_omit == true){
- $V090cbceb = $V090cbceb.';!';
-}else{
- $V090cbceb = $V090cbceb.';';
-}
-}
-} 
- $V21ffce5b['-query'] = $V090cbceb; 
- $V21ffce5b['-findquery'] = true; 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
- function add($Vffbd028a, $Vd0dff0df)
-	{
- $this->Vad2bfd5a[$Vffbd028a] = $Vd0dff0df;
-}
- function addSortRule($Vd1148ee8, $Vffbd028a, $V70a17ffa = null)
-	{
- $this->Vd65662c5[$Vffbd028a] = $Vd1148ee8;
-if ($V70a17ffa !== null) {
- $this->Va9136a07[$Vffbd028a] = $V70a17ffa;
-}
-}
- function clearSortRules()
-	{
- $this->Vd65662c5= array();
-$this->Va9136a07= array();
-}
- function setRange($V08b43519 = 0, $V2ffe4e77 = null)
-	{
- $this->V83f28691= $V08b43519;
-$this->V85fd701e= $V2ffe4e77;
-}
- function getRange()
-	{
- return array('skip' => $this->V83f28691,
- 'max' => $this->V85fd701e);
-}
+            $V4111477f = 0;
+            foreach ($V15c46c6e as $Vd1148ee8 => $Ve9de89b0) {
+                $V21ffce5b['-q' . $Ve2942a04] = $Vd1148ee8;
+                $V21ffce5b['-q' . $Ve2942a04 . '.' . "value"] = $Ve9de89b0;
+                $V090cbceb = $V090cbceb . 'q' . $Ve2942a04;
+                $Ve2942a04++;
+                $V4111477f++;
 
-  function setRelatedSetsFilters($Vdba51d08, $V01a8ebbf = null)
- {
- $this->V6da136ea= $Vdba51d08;
-$this->V568aa2ec= $V01a8ebbf;
-}
- function getRelatedSetsFilters()
- {
- return array('relatedsetsfilter' => $this->V6da136ea,
- 'relatedsetsmax' => $this->V568aa2ec);
-}
- function _setRelatedSetsFilters(&$V21ffce5b)
- {
- if ($this->V6da136ea) {
- $V21ffce5b['-relatedsets.filter'] = $this->V6da136ea;
-}
-if ($this->V568aa2ec) {
- $V21ffce5b['-relatedsets.max'] = $this->V568aa2ec;
-}
-}
- function _setSortParams(&$V21ffce5b)
-	{
- foreach ($this->Vd65662c5 as $Vffbd028a => $Vd1148ee8) {
- $V21ffce5b['-sortfield.' . $Vffbd028a] = $Vd1148ee8;
-}
-foreach ($this->Va9136a07 as $Vffbd028a => $V70a17ffa) {
- $V21ffce5b['-sortorder.' . $Vffbd028a] = $V70a17ffa;
-}
-}
- function _setRangeParams(&$V21ffce5b)
-	{
- if ($this->V83f28691) {
- $V21ffce5b['-skip'] = $this->V83f28691;
-}
-if ($this->V85fd701e) {
- $V21ffce5b['-max'] = $this->V85fd701e;
-}
-}
+                if ($V4111477f < $V8ac10dab) {
+                    $V090cbceb = $V090cbceb . ',';
+                }
+            }
+            $V090cbceb = $V090cbceb . ")";
+            $V40677621++;
+            if ($V40677621 <= $V31c3c8cf) {
+                $V4b22ce92 = $this->Vad2bfd5a[$V40677621];
+                if ($V4b22ce92->_impl->_omit == true) {
+                    $V090cbceb = $V090cbceb . ';!';
+                } else {
+                    $V090cbceb = $V090cbceb . ';';
+                }
+            }
+        }
+        $V21ffce5b['-query'] = $V090cbceb;
+        $V21ffce5b['-findquery'] = true;
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
+    public function add($Vffbd028a, $Vd0dff0df)
+    {
+        $this->Vad2bfd5a[$Vffbd028a] = $Vd0dff0df;
+    }
+    public function addSortRule($Vd1148ee8, $Vffbd028a, $V70a17ffa = null)
+    {
+        $this->Vd65662c5[$Vffbd028a] = $Vd1148ee8;
+        if ($V70a17ffa !== null) {
+            $this->Va9136a07[$Vffbd028a] = $V70a17ffa;
+        }
+    }
+    public function clearSortRules()
+    {
+        $this->Vd65662c5 = array();
+        $this->Va9136a07 = array();
+    }
+    public function setRange($V08b43519 = 0, $V2ffe4e77 = null)
+    {
+        $this->V83f28691 = $V08b43519;
+        $this->V85fd701e = $V2ffe4e77;
+    }
+    public function getRange()
+    {
+        return array('skip' => $this->V83f28691,
+            'max' => $this->V85fd701e);
+    }
+
+    public function setRelatedSetsFilters($Vdba51d08, $V01a8ebbf = null)
+    {
+        $this->V6da136ea = $Vdba51d08;
+        $this->V568aa2ec = $V01a8ebbf;
+    }
+    public function getRelatedSetsFilters()
+    {
+        return array('relatedsetsfilter' => $this->V6da136ea,
+            'relatedsetsmax' => $this->V568aa2ec);
+    }
+    public function _setRelatedSetsFilters(&$V21ffce5b)
+    {
+        if ($this->V6da136ea) {
+            $V21ffce5b['-relatedsets.filter'] = $this->V6da136ea;
+        }
+        if ($this->V568aa2ec) {
+            $V21ffce5b['-relatedsets.max'] = $this->V568aa2ec;
+        }
+    }
+    public function _setSortParams(&$V21ffce5b)
+    {
+        foreach ($this->Vd65662c5 as $Vffbd028a => $Vd1148ee8) {
+            $V21ffce5b['-sortfield.' . $Vffbd028a] = $Vd1148ee8;
+        }
+        foreach ($this->Va9136a07 as $Vffbd028a => $V70a17ffa) {
+            $V21ffce5b['-sortorder.' . $Vffbd028a] = $V70a17ffa;
+        }
+    }
+    public function _setRangeParams(&$V21ffce5b)
+    {
+        if ($this->V83f28691) {
+            $V21ffce5b['-skip'] = $this->V83f28691;
+        }
+        if ($this->V85fd701e) {
+            $V21ffce5b['-max'] = $this->V85fd701e;
+        }
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/DeleteImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/DeleteImpl.php
@@ -1,25 +1,25 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_Delete_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_Delete_Implementation extends FileMaker_Command_Implementation
 {
-  function FileMaker_Command_Delete_Implementation($V0ab34ca9, $Vc6140495, $Va6ec9c02)
- {
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-$this->_recordId = $Va6ec9c02;
-}
- function &execute()
- { 
- if (empty($this->_recordId)) {
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'Delete commands require a record id.');
-return $Vcb5e100e;
-} 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-delete'] = true; 
- $V21ffce5b['-recid'] = $this->_recordId; 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
+    public function __construct($V0ab34ca9, $Vc6140495, $Va6ec9c02)
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        $this->_recordId = $Va6ec9c02;
+    }
+    public function &execute()
+    {
+        if (empty($this->_recordId)) {
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Delete commands require a record id.');
+            return $Vcb5e100e;
+        }
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-delete'] = true;
+        $V21ffce5b['-recid'] = $this->_recordId;
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/DuplicateImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/DuplicateImpl.php
@@ -1,25 +1,25 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_Duplicate_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_Duplicate_Implementation extends FileMaker_Command_Implementation
 {
-  function FileMaker_Command_Duplicate_Implementation($V0ab34ca9, $Vc6140495, $Va6ec9c02)
- {
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-$this->_recordId = $Va6ec9c02;
-}
- function &execute()
- { 
- if (empty($this->_recordId)) {
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'Duplicate commands require a record id.');
-return $Vcb5e100e;
-} 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-dup'] = true; 
- $V21ffce5b['-recid'] = $this->_recordId; 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
+    public function __construct($V0ab34ca9, $Vc6140495, $Va6ec9c02)
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        $this->_recordId = $Va6ec9c02;
+    }
+    public function &execute()
+    {
+        if (empty($this->_recordId)) {
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Duplicate commands require a record id.');
+            return $Vcb5e100e;
+        }
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-dup'] = true;
+        $V21ffce5b['-recid'] = $this->_recordId;
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/EditImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/EditImpl.php
@@ -1,118 +1,125 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_Edit_Implementation extends FileMaker_Command_Implementation {
-	 var $_fields = array ();
- var $_modificationId = null;
- var $V6d6e1fd2;
- function FileMaker_Command_Edit_Implementation($V0ab34ca9, $Vc6140495, $Va6ec9c02, $Va0af1e2b = array ()) {
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-$this->_recordId = $Va6ec9c02;
-$this->V6d6e1fd2= null;
-foreach ($Va0af1e2b as $V06e3d36f => $V2063c160) {
- if (!is_array($V2063c160)) {
- $V2063c160 = array (
- $V2063c160
- );
-}
-$this->_fields[$V06e3d36f] = $V2063c160;
-}
-}
- function & execute() { 
- $V21ffce5b = $this->_getCommandParams(); 
- if (empty ($this->_recordId)) {
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'Edit commands require a record id.');
-return $Vcb5e100e;
-} 
- if (!count($this->_fields)) {  
- if ($this->V6d6e1fd2== null) {
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'There are no changes to make.');
-return $Vcb5e100e;
-}
-}  
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_Edit_Implementation extends FileMaker_Command_Implementation
+{
+    public $_fields = array();
+    public $_modificationId = null;
+    public $V6d6e1fd2;
+    public function __construct($V0ab34ca9, $Vc6140495, $Va6ec9c02, $Va0af1e2b = array())
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        $this->_recordId = $Va6ec9c02;
+        $this->V6d6e1fd2 = null;
+        foreach ($Va0af1e2b as $V06e3d36f => $V2063c160) {
+            if (!is_array($V2063c160)) {
+                $V2063c160 = array(
+                    $V2063c160,
+                );
+            }
+            $this->_fields[$V06e3d36f] = $V2063c160;
+        }
+    }
+    public function &execute()
+    {
+        $V21ffce5b = $this->_getCommandParams();
+        if (empty($this->_recordId)) {
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Edit commands require a record id.');
+            return $Vcb5e100e;
+        }
+        if (!count($this->_fields)) {
+            if ($this->V6d6e1fd2 == null) {
+                $Vcb5e100e = new FileMaker_Error($this->_fm, 'There are no changes to make.');
+                return $Vcb5e100e;
+            }
+        }
 
-if ($this->_fm->getProperty('prevalidate')) {
-$Vcb5e111f = & $this->_fm->getLayout($this->_layout);
-$Vb0689411 = new FileMaker_Error_Validation($this->_fm);
-foreach ($Vcb5e111f->getFields() as $V9f7d0ff7 => $Vc6140945) {
-if (isset ($this->_fields[$V9f7d0ff7])) {
-$V6d6e1ff1 = $this->_fields[$V9f7d0ff7];
-foreach ($V6d6e1ff1 as $V6d6e1ff2) {
-$Vb0689411 = $Vc6140945->validate($V6d6e1ff2);
-if (FileMaker :: isError($Vb0689411)) {
-return $Vb0689411;
-}
-}
-}
-}
-}
+        if ($this->_fm->getProperty('prevalidate')) {
+            $Vcb5e111f = &$this->_fm->getLayout($this->_layout);
+            $Vb0689411 = new FileMaker_Error_Validation($this->_fm);
+            foreach ($Vcb5e111f->getFields() as $V9f7d0ff7 => $Vc6140945) {
+                if (isset($this->_fields[$V9f7d0ff7])) {
+                    $V6d6e1ff1 = $this->_fields[$V9f7d0ff7];
+                    foreach ($V6d6e1ff1 as $V6d6e1ff2) {
+                        $Vb0689411 = $Vc6140945->validate($V6d6e1ff2);
+                        if (FileMaker::isError($Vb0689411)) {
+                            return $Vb0689411;
+                        }
+                    }
+                }
+            }
+        }
 
- $Vc6140495 = & $this->_fm->getLayout($this->_layout);
-if (FileMaker :: isError($Vc6140495)) {
- return $Vc6140495;
-} 
- $V21ffce5b['-edit'] = true; 
- if ($this->V6d6e1fd2== null) {
- foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
- if (strpos($V972bf3f0, '.') !== false) {
- list ($Vb068931c, $V11e868ac) = explode('.', $V972bf3f0, 2);
-$V11e868ac = '.' . $V11e868ac;
-} else {
- $Vb068931c = $V972bf3f0;
-$V06e3d36f = $Vc6140495->getField($V972bf3f0);
-if (FileMaker :: isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-if ($V06e3d36f->isGlobal()) {
- $V11e868ac = '.global';
-} else {
- $V11e868ac = '';
-}
-}
-foreach ($Vee0525e4 as $V6a992d55 => $V3a6d0284) {
- $V21ffce5b[$Vb068931c . '(' . ($V6a992d55 +1) . ')' . $V11e868ac] = $V3a6d0284;
-}
-}
-}
-if ($this->V6d6e1fd2!= null) {
- $V21ffce5b['-delete.related'] = $this->V6d6e1fd2;
-} 
- $V21ffce5b['-recid'] = $this->_recordId; 
- if ($this->_modificationId) {
- $V21ffce5b['-modid'] = $this->_modificationId;
-} 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker :: isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
- function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0) {
- $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
-return $V2063c160;
-}
- function setFieldFromTimestamp($V06e3d36f, $Vd7e6d55b, $V6d786dc7 = 0) {
- $Vc6140495 = & $this->_fm->getLayout($this->_layout);
-if (FileMaker :: isError($Vc6140495)) {
- return $Vc6140495;
-}
-$V06e3d36f = & $Vc6140495->getField($V06e3d36f);
-if (FileMaker :: isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-switch ($V06e3d36f->getResult()) {
- case 'date' :
- return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
-case 'time' :
- return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
-case 'timestamp' :
- return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
-}
-return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
-}
- function setModificationId($Vf048d909) {
- $this->_modificationId = $Vf048d909;
-}
- function _setdeleteRelated($V2063c160) {
- $this->V6d6e1fd2= $V2063c160;
-}
+        $Vc6140495 = &$this->_fm->getLayout($this->_layout);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $V21ffce5b['-edit'] = true;
+        if ($this->V6d6e1fd2 == null) {
+            foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
+                if (strpos($V972bf3f0, '.') !== false) {
+                    list($Vb068931c, $V11e868ac) = explode('.', $V972bf3f0, 2);
+                    $V11e868ac = '.' . $V11e868ac;
+                } else {
+                    $Vb068931c = $V972bf3f0;
+                    $V06e3d36f = $Vc6140495->getField($V972bf3f0);
+                    if (FileMaker::isError($V06e3d36f)) {
+                        return $V06e3d36f;
+                    }
+                    if ($V06e3d36f->isGlobal()) {
+                        $V11e868ac = '.global';
+                    } else {
+                        $V11e868ac = '';
+                    }
+                }
+                foreach ($Vee0525e4 as $V6a992d55 => $V3a6d0284) {
+                    $V21ffce5b[$Vb068931c . '(' . ($V6a992d55 + 1) . ')' . $V11e868ac] = $V3a6d0284;
+                }
+            }
+        }
+        if ($this->V6d6e1fd2 != null) {
+            $V21ffce5b['-delete.related'] = $this->V6d6e1fd2;
+        }
+        $V21ffce5b['-recid'] = $this->_recordId;
+        if ($this->_modificationId) {
+            $V21ffce5b['-modid'] = $this->_modificationId;
+        }
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
+    public function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0)
+    {
+        $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
+        return $V2063c160;
+    }
+    public function setFieldFromTimestamp($V06e3d36f, $Vd7e6d55b, $V6d786dc7 = 0)
+    {
+        $Vc6140495 = &$this->_fm->getLayout($this->_layout);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $V06e3d36f = &$Vc6140495->getField($V06e3d36f);
+        if (FileMaker::isError($V06e3d36f)) {
+            return $V06e3d36f;
+        }
+        switch ($V06e3d36f->getResult()) {
+            case 'date':
+                return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
+            case 'time':
+                return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
+            case 'timestamp':
+                return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
+        }
+        return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
+    }
+    public function setModificationId($Vf048d909)
+    {
+        $this->_modificationId = $Vf048d909;
+    }
+    public function _setdeleteRelated($V2063c160)
+    {
+        $this->V6d6e1fd2 = $V2063c160;
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/FindAllImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindAllImpl.php
@@ -1,21 +1,22 @@
 <?php
-  require_once dirname(__FILE__) . '/FindImpl.php';
- class FileMaker_Command_FindAll_Implementation extends FileMaker_Command_Find_Implementation
+require_once dirname(__FILE__) . '/FindImpl.php';
+class FileMaker_Command_FindAll_Implementation extends FileMaker_Command_Find_Implementation
 {
-  function FileMaker_Command_FindAll_Implementation($V0ab34ca9, $Vc6140495) {
- FileMaker_Command_Find_Implementation::FileMaker_Command_Find_Implementation($V0ab34ca9, $Vc6140495);
-}
+    public function __construct($V0ab34ca9, $Vc6140495)
+    {
+        FileMaker_Command_Find_Implementation::FileMaker_Command_Find_Implementation($V0ab34ca9, $Vc6140495);
+    }
 
-  function &execute()
- { 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-findall'] = true; 
- $this->_setSortParams($V21ffce5b);
-$this->_setRangeParams($V21ffce5b); 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
+    public function &execute()
+    {
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-findall'] = true;
+        $this->_setSortParams($V21ffce5b);
+        $this->_setRangeParams($V21ffce5b);
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/FindAnyImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindAnyImpl.php
@@ -1,19 +1,20 @@
 <?php
-  require_once dirname(__FILE__) . '/FindImpl.php';
- class FileMaker_Command_FindAny_Implementation extends FileMaker_Command_Find_Implementation
+require_once dirname(__FILE__) . '/FindImpl.php';
+class FileMaker_Command_FindAny_Implementation extends FileMaker_Command_Find_Implementation
 {
-  function FileMaker_Command_FindAny_Implementation($V0ab34ca9, $Vc6140495) {
- FileMaker_Command_Find_Implementation::FileMaker_Command_Find_Implementation($V0ab34ca9, $Vc6140495);
-}
+    public function __construct($V0ab34ca9, $Vc6140495)
+    {
+        FileMaker_Command_Find_Implementation::FileMaker_Command_Find_Implementation($V0ab34ca9, $Vc6140495);
+    }
 
-  function &execute()
- { 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-findany'] = true; 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
+    public function &execute()
+    {
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-findany'] = true;
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
@@ -11,10 +11,12 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
 
     public $V6da136ea;
     public $V568aa2ec;
+
     public function __construct($V0ab34ca9, $Vc6140495)
     {
         parent::__construct($V0ab34ca9, $Vc6140495);
     }
+
     public function &execute()
     {
         $V21ffce5b = $this->_getCommandParams();
@@ -41,14 +43,17 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
         }
         return $this->_getResult($V0f635d0e);
     }
+
     public function addFindCriterion($Vd1148ee8, $Ve9de89b0)
     {
         $this->_findCriteria[$Vd1148ee8] = $Ve9de89b0;
     }
+
     public function clearFindCriteria()
     {
         $this->_findCriteria = array();
     }
+
     public function addSortRule($Vd1148ee8, $Vffbd028a, $V70a17ffa = null)
     {
         $this->Vd65662c5[$Vffbd028a] = $Vd1148ee8;
@@ -56,11 +61,13 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
             $this->Va9136a07[$Vffbd028a] = $V70a17ffa;
         }
     }
+
     public function clearSortRules()
     {
         $this->Vd65662c5 = array();
         $this->Va9136a07 = array();
     }
+
     public function setLogicalOperator($V4b583376)
     {
         switch ($V4b583376) {
@@ -70,26 +77,31 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
                 break;
         }
     }
+
     public function setRange($V08b43519 = 0, $V2ffe4e77 = null)
     {
         $this->V83f28691 = $V08b43519;
         $this->V85fd701e = $V2ffe4e77;
     }
+
     public function getRange()
     {
         return array('skip' => $this->V83f28691,
             'max' => $this->V85fd701e);
     }
+
     public function setRelatedSetsFilters($Vdba51d08, $V01a8ebbf = null)
     {
         $this->V6da136ea = $Vdba51d08;
         $this->V568aa2ec = $V01a8ebbf;
     }
+
     public function getRelatedSetsFilters()
     {
         return array('relatedsetsfilter' => $this->V6da136ea,
             'relatedsetsmax' => $this->V568aa2ec);
     }
+
     public function _setRelatedSetsFilters(&$V21ffce5b)
     {
         if ($this->V6da136ea) {
@@ -99,6 +111,7 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
             $V21ffce5b['-relatedsets.max'] = $this->V568aa2ec;
         }
     }
+
     public function _setSortParams(&$V21ffce5b)
     {
         foreach ($this->Vd65662c5 as $Vffbd028a => $Vd1148ee8) {
@@ -108,6 +121,7 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
             $V21ffce5b['-sortorder.' . $Vffbd028a] = $V70a17ffa;
         }
     }
+
     public function _setRangeParams(&$V21ffce5b)
     {
         if ($this->V83f28691) {

--- a/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
@@ -13,7 +13,7 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
     public $V568aa2ec;
     public function __construct($V0ab34ca9, $Vc6140495)
     {
-        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        FileMaker_Command_Implementation::__construct($V0ab34ca9, $Vc6140495);
     }
     public function &execute()
     {

--- a/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
@@ -1,120 +1,120 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementation
 {
-  var $_findCriteria = array();
- var $Vd65662c5 = array();
- var $Va9136a07 = array();
- var $Vf951bdce;
- var $V83f28691;
- var $V85fd701e;
+    public $_findCriteria = array();
+    public $Vd65662c5 = array();
+    public $Va9136a07 = array();
+    public $Vf951bdce;
+    public $V83f28691;
+    public $V85fd701e;
 
-  var $V6da136ea;
- var $V568aa2ec;
- function FileMaker_Command_Find_Implementation($V0ab34ca9, $Vc6140495)
- {
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-}
- function &execute()
- { 
- $V21ffce5b = $this->_getCommandParams(); 
- $this->_setSortParams($V21ffce5b);
-$this->_setRangeParams($V21ffce5b);
-$this->_setRelatedSetsFilters($V21ffce5b);   
- if (count($this->_findCriteria) || $this->_recordId) {
- $V21ffce5b['-find'] = true;
-} else {
- $V21ffce5b['-findall'] = true;
-} 
- if ($this->_recordId) {
- $V21ffce5b['-recid'] = $this->_recordId;
-} 
- if ($this->Vf951bdce) {
- $V21ffce5b['-lop'] = $this->Vf951bdce;
-} 
- foreach ($this->_findCriteria as $Vd1148ee8 => $Ve9de89b0) {
- $V21ffce5b[$Vd1148ee8] = $Ve9de89b0;
-} 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
- function addFindCriterion($Vd1148ee8, $Ve9de89b0)
- {
- $this->_findCriteria[$Vd1148ee8] = $Ve9de89b0;
-}
- function clearFindCriteria()
- {
- $this->_findCriteria = array();
-}
- function addSortRule($Vd1148ee8, $Vffbd028a, $V70a17ffa = null)
- {
- $this->Vd65662c5[$Vffbd028a] = $Vd1148ee8;
-if ($V70a17ffa !== null) {
- $this->Va9136a07[$Vffbd028a] = $V70a17ffa;
-}
-}
- function clearSortRules()
- {
- $this->Vd65662c5= array();
-$this->Va9136a07= array();
-}
- function setLogicalOperator($V4b583376)
- {
- switch ($V4b583376) {
- case FILEMAKER_FIND_AND:
- case FILEMAKER_FIND_OR:
- $this->Vf951bdce= $V4b583376;
-break;
-}
-}
- function setRange($V08b43519 = 0, $V2ffe4e77 = null)
- {
- $this->V83f28691= $V08b43519;
-$this->V85fd701e= $V2ffe4e77;
-}
- function getRange()
- {
- return array('skip' => $this->V83f28691,
- 'max' => $this->V85fd701e);
-}
- function setRelatedSetsFilters($Vdba51d08, $V01a8ebbf = null)
- {
- $this->V6da136ea= $Vdba51d08;
-$this->V568aa2ec= $V01a8ebbf;
-}
- function getRelatedSetsFilters()
- {
- return array('relatedsetsfilter' => $this->V6da136ea,
- 'relatedsetsmax' => $this->V568aa2ec);
-}
- function _setRelatedSetsFilters(&$V21ffce5b)
- {
- if ($this->V6da136ea) {
- $V21ffce5b['-relatedsets.filter'] = $this->V6da136ea;
-}
-if ($this->V568aa2ec) {
- $V21ffce5b['-relatedsets.max'] = $this->V568aa2ec;
-}
-}
- function _setSortParams(&$V21ffce5b)
- {
- foreach ($this->Vd65662c5 as $Vffbd028a => $Vd1148ee8) {
- $V21ffce5b['-sortfield.' . $Vffbd028a] = $Vd1148ee8;
-}
-foreach ($this->Va9136a07 as $Vffbd028a => $V70a17ffa) {
- $V21ffce5b['-sortorder.' . $Vffbd028a] = $V70a17ffa;
-}
-}
- function _setRangeParams(&$V21ffce5b)
- {
- if ($this->V83f28691) {
- $V21ffce5b['-skip'] = $this->V83f28691;
-}
-if ($this->V85fd701e) {
- $V21ffce5b['-max'] = $this->V85fd701e;
-}
-}
+    public $V6da136ea;
+    public $V568aa2ec;
+    public function __construct($V0ab34ca9, $Vc6140495)
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+    }
+    public function &execute()
+    {
+        $V21ffce5b = $this->_getCommandParams();
+        $this->_setSortParams($V21ffce5b);
+        $this->_setRangeParams($V21ffce5b);
+        $this->_setRelatedSetsFilters($V21ffce5b);
+        if (count($this->_findCriteria) || $this->_recordId) {
+            $V21ffce5b['-find'] = true;
+        } else {
+            $V21ffce5b['-findall'] = true;
+        }
+        if ($this->_recordId) {
+            $V21ffce5b['-recid'] = $this->_recordId;
+        }
+        if ($this->Vf951bdce) {
+            $V21ffce5b['-lop'] = $this->Vf951bdce;
+        }
+        foreach ($this->_findCriteria as $Vd1148ee8 => $Ve9de89b0) {
+            $V21ffce5b[$Vd1148ee8] = $Ve9de89b0;
+        }
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
+    public function addFindCriterion($Vd1148ee8, $Ve9de89b0)
+    {
+        $this->_findCriteria[$Vd1148ee8] = $Ve9de89b0;
+    }
+    public function clearFindCriteria()
+    {
+        $this->_findCriteria = array();
+    }
+    public function addSortRule($Vd1148ee8, $Vffbd028a, $V70a17ffa = null)
+    {
+        $this->Vd65662c5[$Vffbd028a] = $Vd1148ee8;
+        if ($V70a17ffa !== null) {
+            $this->Va9136a07[$Vffbd028a] = $V70a17ffa;
+        }
+    }
+    public function clearSortRules()
+    {
+        $this->Vd65662c5 = array();
+        $this->Va9136a07 = array();
+    }
+    public function setLogicalOperator($V4b583376)
+    {
+        switch ($V4b583376) {
+            case FILEMAKER_FIND_AND:
+            case FILEMAKER_FIND_OR:
+                $this->Vf951bdce = $V4b583376;
+                break;
+        }
+    }
+    public function setRange($V08b43519 = 0, $V2ffe4e77 = null)
+    {
+        $this->V83f28691 = $V08b43519;
+        $this->V85fd701e = $V2ffe4e77;
+    }
+    public function getRange()
+    {
+        return array('skip' => $this->V83f28691,
+            'max' => $this->V85fd701e);
+    }
+    public function setRelatedSetsFilters($Vdba51d08, $V01a8ebbf = null)
+    {
+        $this->V6da136ea = $Vdba51d08;
+        $this->V568aa2ec = $V01a8ebbf;
+    }
+    public function getRelatedSetsFilters()
+    {
+        return array('relatedsetsfilter' => $this->V6da136ea,
+            'relatedsetsmax' => $this->V568aa2ec);
+    }
+    public function _setRelatedSetsFilters(&$V21ffce5b)
+    {
+        if ($this->V6da136ea) {
+            $V21ffce5b['-relatedsets.filter'] = $this->V6da136ea;
+        }
+        if ($this->V568aa2ec) {
+            $V21ffce5b['-relatedsets.max'] = $this->V568aa2ec;
+        }
+    }
+    public function _setSortParams(&$V21ffce5b)
+    {
+        foreach ($this->Vd65662c5 as $Vffbd028a => $Vd1148ee8) {
+            $V21ffce5b['-sortfield.' . $Vffbd028a] = $Vd1148ee8;
+        }
+        foreach ($this->Va9136a07 as $Vffbd028a => $V70a17ffa) {
+            $V21ffce5b['-sortorder.' . $Vffbd028a] = $V70a17ffa;
+        }
+    }
+    public function _setRangeParams(&$V21ffce5b)
+    {
+        if ($this->V83f28691) {
+            $V21ffce5b['-skip'] = $this->V83f28691;
+        }
+        if ($this->V85fd701e) {
+            $V21ffce5b['-max'] = $this->V85fd701e;
+        }
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindImpl.php
@@ -13,7 +13,7 @@ class FileMaker_Command_Find_Implementation extends FileMaker_Command_Implementa
     public $V568aa2ec;
     public function __construct($V0ab34ca9, $Vc6140495)
     {
-        FileMaker_Command_Implementation::__construct($V0ab34ca9, $Vc6140495);
+        parent::__construct($V0ab34ca9, $Vc6140495);
     }
     public function &execute()
     {

--- a/src/FMAPI/FileMaker/Implementation/Command/FindRequestImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/FindRequestImpl.php
@@ -1,26 +1,26 @@
 <?php
- require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_FindRequest_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_FindRequest_Implementation
 {
-  var $_findCriteria = array();
+    public $_findCriteria = array();
 
-  var $_omit;
- function FileMaker_Command_FindRequest_Implementation()
- {
- $this->_omit = false;
-}
+    public $_omit;
+    public function __construct()
+    {
+        $this->_omit = false;
+    }
 
-  function addFindCriterion($Vd1148ee8, $Ve9de89b0)
- {
- $this->_findCriteria[$Vd1148ee8] = $Ve9de89b0;
-}
- function setOmit($V2063c160)
- {
- $this->_omit = $V2063c160;
-}
+    public function addFindCriterion($Vd1148ee8, $Ve9de89b0)
+    {
+        $this->_findCriteria[$Vd1148ee8] = $Ve9de89b0;
+    }
+    public function setOmit($V2063c160)
+    {
+        $this->_omit = $V2063c160;
+    }
 
-  function clearFindCriteria()
- {
- $this->_findCriteria = array();
-}
+    public function clearFindCriteria()
+    {
+        $this->_findCriteria = array();
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Command/PerformScriptImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/Command/PerformScriptImpl.php
@@ -1,21 +1,21 @@
 <?php
-  require_once dirname(__FILE__) . '/../CommandImpl.php';
- class FileMaker_Command_PerformScript_Implementation extends FileMaker_Command_Implementation
+require_once dirname(__FILE__) . '/../CommandImpl.php';
+class FileMaker_Command_PerformScript_Implementation extends FileMaker_Command_Implementation
 {
-  function FileMaker_Command_PerformScript_Implementation($V0ab34ca9, $Vc6140495, $V2550889a, $V9b479e5e = null)
- {
- FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
-$this->_script = $V2550889a;
-$this->_scriptParams = $V9b479e5e;
-}
- function execute()
- { 
- $V21ffce5b = $this->_getCommandParams(); 
- $V21ffce5b['-findany'] = true; 
- $V0f635d0e = $this->_fm->_execute($V21ffce5b);
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-} 
- return $this->_getResult($V0f635d0e);
-}
+    public function __construct($V0ab34ca9, $Vc6140495, $V2550889a, $V9b479e5e = null)
+    {
+        FileMaker_Command_Implementation::FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495);
+        $this->_script = $V2550889a;
+        $this->_scriptParams = $V9b479e5e;
+    }
+    public function execute()
+    {
+        $V21ffce5b = $this->_getCommandParams();
+        $V21ffce5b['-findany'] = true;
+        $V0f635d0e = $this->_fm->_execute($V21ffce5b);
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        return $this->_getResult($V0f635d0e);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/CommandImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/CommandImpl.php
@@ -1,117 +1,128 @@
 <?php
-  require_once dirname(__FILE__) . '/../Error/Validation.php';
- require_once dirname(__FILE__) . '/../Result.php';
- class FileMaker_Command_Implementation {
-	 var $_fm;
- var $_layout;
- var $V7a2db0ea;
- var $_script;
- var $_scriptParams;
- var $_preReqScript;
- var $_preReqScriptParams;
- var $_preSortScript;
- var $_preSortScriptParams;
- var $V0b9a204c;
- var $_recordId;
- function FileMaker_Command_Implementation($V0ab34ca9, $Vc6140495) {
- $this->_fm =& $V0ab34ca9;
-$this->_layout = $Vc6140495; 
- $this->V0b9a204c= $V0ab34ca9->getProperty('recordClass');
-}
- function setResultLayout($Vc6140495) {
- $this->V7a2db0ea= $Vc6140495;
-}
- function setScript($V2550889a, $V9b479e5e = null) {
- $this->_script = $V2550889a;
-$this->_scriptParams = $V9b479e5e;
-}
- function setPreCommandScript($V2550889a, $V9b479e5e = null) {
- $this->_preReqScript = $V2550889a;
-$this->_preReqScriptParams = $V9b479e5e;
-}
- function setPreSortScript($V2550889a, $V9b479e5e = null) {
- $this->_preSortScript = $V2550889a;
-$this->_preSortScriptParams = $V9b479e5e;
-}
- function setRecordClass($V6f66e878) {
- $this->V0b9a204c= $V6f66e878;
-}
- function setRecordId($Va6ec9c02) {
- $this->_recordId = $Va6ec9c02;
-}
- function validate($V972bf3f0 = null) {  
- if (!is_a($this, 'FileMaker_Command_Add_Implementation') && !is_a($this, 'FileMaker_Command_Edit_Implementation')) {
- return true;
-}
-$Vc6140495 = & $this->_fm->getLayout($this->_layout);
-if (FileMaker :: isError($Vc6140495)) {
- return $Vc6140495;
-} 
- $Vcb5e100e = new FileMaker_Error_Validation($this->_fm);
-if ($V972bf3f0 === null) {   
- foreach ($Vc6140495->getFields() as $V972bf3f0 => $V06e3d36f) {  
- if (!isset ($this->_fields[$V972bf3f0]) || !count($this->_fields[$V972bf3f0])) {
- $Vf09cc7ee = array (
- 0 => null
- );
-} else {
- $Vf09cc7ee = $this->_fields[$V972bf3f0];
-}
-foreach ($Vf09cc7ee as $V2063c160) {
- $Vcb5e100e = $V06e3d36f->validate($V2063c160, $Vcb5e100e);
-}
-}
-} else { 
- $V06e3d36f = & $Vc6140495->getField($V972bf3f0);
-if (FileMaker :: isError($V06e3d36f)) {
- return $V06e3d36f;
-}  
- if (!isset ($this->_fields[$V972bf3f0]) || !count($this->_fields[$V972bf3f0])) {
- $Vf09cc7ee = array (
- 0 => null
- );
-} else {
- $Vf09cc7ee = $this->_fields[$V972bf3f0];
-}
-foreach ($Vf09cc7ee as $V2063c160) {
- $Vcb5e100e = $V06e3d36f->validate($V2063c160, $Vcb5e100e);
-}
-}  
- return $Vcb5e100e->numErrors() ? $Vcb5e100e : true;
-}
- function & _getResult($V0f635d0e) {
- $V3643b863 = new FileMaker_Parser_FMResultSet($this->_fm);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker :: isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$Vd1fc8eaf = new FileMaker_Result($this->_fm);
-$Vb4a88417 = $V3643b863->setResult($Vd1fc8eaf, $this->V0b9a204c);
-if (FileMaker :: isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return $Vd1fc8eaf;
-}
- function _getCommandParams() { 
- $V21ffce5b = array (
- '-db' => $this->_fm->getProperty('database'
- ), '-lay' => $this->_layout); 
- foreach (array (
- '_script' => '-script',
- '_preReqScript' => '-script.prefind',
- '_preSortScript' => '-script.presort'
- ) as $Vb2145aac => $Veca07335) {
- if ($this-> $Vb2145aac) {
- $V21ffce5b[$Veca07335] = $this-> $Vb2145aac;
-$Vb2145aac .= 'Params';
-if ($this-> $Vb2145aac !== null) {
- $V21ffce5b[$Veca07335 . '.param'] = $this-> $Vb2145aac;
-}
-}
-} 
- if ($this->V7a2db0ea) {
- $V21ffce5b['-lay.response'] = $this->V7a2db0ea;
-}
-return $V21ffce5b;
-}
+require_once dirname(__FILE__) . '/../Error/Validation.php';
+require_once dirname(__FILE__) . '/../Result.php';
+class FileMaker_Command_Implementation
+{
+    public $_fm;
+    public $_layout;
+    public $V7a2db0ea;
+    public $_script;
+    public $_scriptParams;
+    public $_preReqScript;
+    public $_preReqScriptParams;
+    public $_preSortScript;
+    public $_preSortScriptParams;
+    public $V0b9a204c;
+    public $_recordId;
+    public function __construct($V0ab34ca9, $Vc6140495)
+    {
+        $this->_fm = &$V0ab34ca9;
+        $this->_layout = $Vc6140495;
+        $this->V0b9a204c = $V0ab34ca9->getProperty('recordClass');
+    }
+    public function setResultLayout($Vc6140495)
+    {
+        $this->V7a2db0ea = $Vc6140495;
+    }
+    public function setScript($V2550889a, $V9b479e5e = null)
+    {
+        $this->_script = $V2550889a;
+        $this->_scriptParams = $V9b479e5e;
+    }
+    public function setPreCommandScript($V2550889a, $V9b479e5e = null)
+    {
+        $this->_preReqScript = $V2550889a;
+        $this->_preReqScriptParams = $V9b479e5e;
+    }
+    public function setPreSortScript($V2550889a, $V9b479e5e = null)
+    {
+        $this->_preSortScript = $V2550889a;
+        $this->_preSortScriptParams = $V9b479e5e;
+    }
+    public function setRecordClass($V6f66e878)
+    {
+        $this->V0b9a204c = $V6f66e878;
+    }
+    public function setRecordId($Va6ec9c02)
+    {
+        $this->_recordId = $Va6ec9c02;
+    }
+    public function validate($V972bf3f0 = null)
+    {
+        if (!is_a($this, 'FileMaker_Command_Add_Implementation') && !is_a($this, 'FileMaker_Command_Edit_Implementation')) {
+            return true;
+        }
+        $Vc6140495 = &$this->_fm->getLayout($this->_layout);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $Vcb5e100e = new FileMaker_Error_Validation($this->_fm);
+        if ($V972bf3f0 === null) {
+            foreach ($Vc6140495->getFields() as $V972bf3f0 => $V06e3d36f) {
+                if (!isset($this->_fields[$V972bf3f0]) || !count($this->_fields[$V972bf3f0])) {
+                    $Vf09cc7ee = array(
+                        0 => null,
+                    );
+                } else {
+                    $Vf09cc7ee = $this->_fields[$V972bf3f0];
+                }
+                foreach ($Vf09cc7ee as $V2063c160) {
+                    $Vcb5e100e = $V06e3d36f->validate($V2063c160, $Vcb5e100e);
+                }
+            }
+        } else {
+            $V06e3d36f = &$Vc6140495->getField($V972bf3f0);
+            if (FileMaker::isError($V06e3d36f)) {
+                return $V06e3d36f;
+            }
+            if (!isset($this->_fields[$V972bf3f0]) || !count($this->_fields[$V972bf3f0])) {
+                $Vf09cc7ee = array(
+                    0 => null,
+                );
+            } else {
+                $Vf09cc7ee = $this->_fields[$V972bf3f0];
+            }
+            foreach ($Vf09cc7ee as $V2063c160) {
+                $Vcb5e100e = $V06e3d36f->validate($V2063c160, $Vcb5e100e);
+            }
+        }
+        return $Vcb5e100e->numErrors() ? $Vcb5e100e : true;
+    }
+    public function &_getResult($V0f635d0e)
+    {
+        $V3643b863 = new FileMaker_Parser_FMResultSet($this->_fm);
+        $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $Vd1fc8eaf = new FileMaker_Result($this->_fm);
+        $Vb4a88417 = $V3643b863->setResult($Vd1fc8eaf, $this->V0b9a204c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return $Vd1fc8eaf;
+    }
+    public function _getCommandParams()
+    {
+        $V21ffce5b = array(
+            '-db' => $this->_fm->getProperty('database'
+            ), '-lay' => $this->_layout);
+        foreach (array(
+            '_script' => '-script',
+            '_preReqScript' => '-script.prefind',
+            '_preSortScript' => '-script.presort',
+        ) as $Vb2145aac => $Veca07335) {
+            if ($this->$Vb2145aac) {
+                $V21ffce5b[$Veca07335] = $this->$Vb2145aac;
+                $Vb2145aac .= 'Params';
+                if ($this->$Vb2145aac !== null) {
+                    $V21ffce5b[$Veca07335 . '.param'] = $this->$Vb2145aac;
+                }
+            }
+        }
+        if ($this->V7a2db0ea) {
+            $V21ffce5b['-lay.response'] = $this->V7a2db0ea;
+        }
+        return $V21ffce5b;
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/FieldImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/FieldImpl.php
@@ -1,344 +1,346 @@
 <?php
-  require_once dirname(__FILE__) . '/../Error/Validation.php';
- class FileMaker_Field_Implementation
+require_once dirname(__FILE__) . '/../Error/Validation.php';
+class FileMaker_Field_Implementation
 {
-  var $_layout;
- var $_name;
- var $_autoEntered = false;
- var $_global = false;
- var $_maxRepeat = 1;
- var $_validationMask = 0;
- var $_validationRules = array();
- var $_result;
- var $_type;
- var $_valueList = null;
- var $_styleType;
- var $_maxCharacters = 0;
- function FileMaker_Field_Implementation(&$Vc6140495)
- {
- $this->_layout =& $Vc6140495;
-}
- function getName()
- {
- return $this->_name;
-}
- function &getLayout()
- {
- return $this->_layout;
-}
- function isAutoEntered()
- {
- return $this->_autoEntered;
-}
- function isGlobal()
- {
- return $this->_global;
-}
- function getRepetitionCount()
- {
- return $this->_maxRepeat;
-}
- function validate($V2063c160, $Vcb5e100e = null)
- {
- $V1c0c74f6 = true;
-if ($Vcb5e100e === null) {
- $V1c0c74f6 = false;
-$Vcb5e100e = new FileMaker_Error_Validation($this->_layout->_impl->_fm);
-}
-foreach ($this->getValidationRules() as $V981c1e7b) {
- switch ($V981c1e7b) {
- case FILEMAKER_RULE_NOTEMPTY:
- if (empty($V2063c160)) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-break;
-case FILEMAKER_RULE_NUMERICONLY :
- if (!empty ($V2063c160)) {
- if ($this->checkNumericOnly($V2063c160)) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-break;
-case FILEMAKER_RULE_MAXCHARACTERS :
- if (!empty ($V2063c160)) {
- $V2fa47f7c = strlen($V2063c160);
-if ($V2fa47f7c > $this->_maxCharacters) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-break;
-case FILEMAKER_RULE_TIME_FIELD :
- if (!empty ($V2063c160)) {
- if (!$this->checkTimeFormat($V2063c160)) {
- 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else {
- $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, FALSE);
-}
-}
-break;
-case FILEMAKER_RULE_TIMESTAMP_FIELD :
- if (!empty ($V2063c160)) {
- if (!$this->checkTimeStampFormat($V2063c160)) {
- 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else {
- $this->checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e);
-$this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, FALSE);
-}
-}
-break;
-case FILEMAKER_RULE_DATE_FIELD :
- if (!empty ($V2063c160)) {
- if (!$this->checkDateFormat($V2063c160)) {
- 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else {
- $this->checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e);
-}
-}
-break;
-case FILEMAKER_RULE_FOURDIGITYEAR :
- if (!empty ($V2063c160)) {
- switch ($this->_result) {
- case 'timestamp' : 
- if ($this->checkTimeStampFormatFourDigitYear($V2063c160)) { 
- preg_match('#^([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{4})#', $V2063c160, $V9c28d32d);
-$V7436f942 = $V9c28d32d[1];
-$V628b7db0 = $V9c28d32d[2];
-$V84cdc76c = $V9c28d32d[3];  
- if ($V84cdc76c < 1 || $V84cdc76c > 4000) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else
- if (!checkdate($V7436f942, $V628b7db0, $V84cdc76c)) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else { 
- $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, FALSE);
-}
-} else {
- 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-break;
-default :
- preg_match('#([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{1,4})#', $V2063c160, $V78f0805f);
-if (count($V78f0805f) != 3) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else {
- $V6c8f3f79 = strlen($V78f0805f[2]);
-if ($V6c8f3f79 != 4) { 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else { 
- if ($V78f0805f[2] < 1 || $V78f0805f[2] > 4000) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else { 
- if (!checkdate($V78f0805f[0], $V78f0805f[1], $V78f0805f[2])) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-}
-}
-break;
-} 
- }
-break;
-case FILEMAKER_RULE_TIMEOFDAY :
- if (!empty ($V2063c160)) { 
- if ($this->checkTimeFormat($V2063c160)) { 
- $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, TRUE);
-} else {
- 
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-break;
-} 
- }   
- if ($V1c0c74f6) {
- return $Vcb5e100e;
-} else {  
- return $Vcb5e100e->numErrors() ? $Vcb5e100e : true;
-}
-}
+    public $_layout;
+    public $_name;
+    public $_autoEntered = false;
+    public $_global = false;
+    public $_maxRepeat = 1;
+    public $_validationMask = 0;
+    public $_validationRules = array();
+    public $_result;
+    public $_type;
+    public $_valueList = null;
+    public $_styleType;
+    public $_maxCharacters = 0;
+    public function __construct(&$Vc6140495)
+    {
+        $this->_layout = &$Vc6140495;
+    }
+    public function getName()
+    {
+        return $this->_name;
+    }
+    public function &getLayout()
+    {
+        return $this->_layout;
+    }
+    public function isAutoEntered()
+    {
+        return $this->_autoEntered;
+    }
+    public function isGlobal()
+    {
+        return $this->_global;
+    }
+    public function getRepetitionCount()
+    {
+        return $this->_maxRepeat;
+    }
+    public function validate($V2063c160, $Vcb5e100e = null)
+    {
+        $V1c0c74f6 = true;
+        if ($Vcb5e100e === null) {
+            $V1c0c74f6 = false;
+            $Vcb5e100e = new FileMaker_Error_Validation($this->_layout->_impl->_fm);
+        }
+        foreach ($this->getValidationRules() as $V981c1e7b) {
+            switch ($V981c1e7b) {
+                case FILEMAKER_RULE_NOTEMPTY:
+                    if (empty($V2063c160)) {
+                        $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                    }
+                    break;
+                case FILEMAKER_RULE_NUMERICONLY:
+                    if (!empty($V2063c160)) {
+                        if ($this->checkNumericOnly($V2063c160)) {
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_MAXCHARACTERS:
+                    if (!empty($V2063c160)) {
+                        $V2fa47f7c = strlen($V2063c160);
+                        if ($V2fa47f7c > $this->_maxCharacters) {
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_TIME_FIELD:
+                    if (!empty($V2063c160)) {
+                        if (!$this->checkTimeFormat($V2063c160)) {
 
-	 function getLocalValidationRules() 
-	{
- $V6b55d9ec = array ();
-foreach (array_keys($this->_validationRules) as $V981c1e7b) {
- switch ($V981c1e7b) {
- case FILEMAKER_RULE_NOTEMPTY :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_NUMERICONLY :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_MAXCHARACTERS :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_FOURDIGITYEAR :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_TIMEOFDAY :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_TIMESTAMP_FIELD :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_DATE_FIELD :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-case FILEMAKER_RULE_TIME_FIELD :
- $V6b55d9ec[] = $V981c1e7b;
-break;
-}
-}
-return $V6b55d9ec;
-}
-function checkTimeStampFormatFourDigitYear($V2063c160) 
-	{
- return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{4})[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
-}
-function checkTimeStampFormat($V2063c160) 
-	{
- return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
-}
-function checkDateFormat($V2063c160) 
-	{
- return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?[ ]*$#', $V2063c160));
-}
-function checkTimeFormat($V2063c160) 
-	{
- return (preg_match('#^[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
-}
-function checkNumericOnly($V2063c160) 
-	{
- return (!is_numeric($V2063c160));
-}
-function checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e) 
-	{
- preg_match('#([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?#', $V2063c160, $V78f0805f);
-if ($V78f0805f[4]) {
- $V6c8f3f79 = strlen($V78f0805f[4]);
-$V84cdc76c = $V78f0805f[4];
-if ($V6c8f3f79 != 4) {
- $V84cdc76c = $V84cdc76c +2000;
-} 
- if ($V78f0805f[4] < 1 || $V78f0805f[4] > 4000) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else { 
- if (!checkdate($V78f0805f[1], $V78f0805f[2], $V78f0805f[4])) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-} else {
- $V84cdc76c = date('Y');
-if (!checkdate($V78f0805f[1], $V78f0805f[2], $V84cdc76c)) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
-}
-function checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, $Vcaf85b7b) 
-	{
- $V52124c01 = 0;
-if ($Vcaf85b7b) {
- $V52124c01 = 12;
-} else {
- $V52124c01 = 24;
-} 
- preg_match('#([0-9]{1,2})[:]([0-9]{1,2})[:]?([0-9]{1,2})?#', $V2063c160, $V9c28d32d);
-$V896c55cc = $V9c28d32d[1];
-$V640fd0cc = $V9c28d32d[2];
-if (count($V9c28d32d) >= 4) {
- $V783e8e29 = $V9c28d32d[3];
-} 
- if ($V896c55cc < 0 || $V896c55cc > $V52124c01) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else if ($V640fd0cc < 0 || $V640fd0cc > 59) {
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-} else
- if (isset($V783e8e29)) {
- if ($V783e8e29 < 0 || $V783e8e29 > 59)
- $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
-}
-}
- function getValidationRules()
- {
- return array_keys($this->_validationRules);
-}
- function getValidationMask()
- {
- return $this->_validationMask;
-}
- function hasValidationRule($Ve289cc97)
- {
- return $Ve289cc97 & $this->_validationMask;
-}
- function describeValidationRule($Ve289cc97)
- {
- if (is_array($this->_validationRules[$Ve289cc97])) {
- return $this->_validationRules[$Ve289cc97];
-}
-return null;
-}
- function describeLocalValidationRules() 
-	{
- $V6b55d9ec = array ();
-foreach ($this->_validationRules as $V981c1e7b => $V1dee80c7) {
- switch ($V981c1e7b) {
- case FILEMAKER_RULE_NOTEMPTY :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_NUMERICONLY :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_MAXCHARACTERS :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_FOURDIGITYEAR :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_TIMEOFDAY :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_TIMESTAMP_FIELD :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_DATE_FIELD :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-case FILEMAKER_RULE_TIME_FIELD :
- $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
-break;
-}
-}
-return $V6b55d9ec;
-}
- function describeValidationRules()
- {
- return $this->_validationRules;
-}
- function getResult()
- {
- return $this->_result;
-}
- function getType()
- {
- return $this->_type;
-}
- function getValueList($Vd33e904c = null)
- {
- $Vb4a88417 = $this->_layout->loadExtendedInfo($Vd33e904c);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return $this->_layout->getValueList($this->_valueList);
-}
- function getStyleType()
- {
- $Vb4a88417 = $this->_layout->loadExtendedInfo();
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return $this->_styleType;
-}
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        } else {
+                            $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, false);
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_TIMESTAMP_FIELD:
+                    if (!empty($V2063c160)) {
+                        if (!$this->checkTimeStampFormat($V2063c160)) {
+
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        } else {
+                            $this->checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e);
+                            $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, false);
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_DATE_FIELD:
+                    if (!empty($V2063c160)) {
+                        if (!$this->checkDateFormat($V2063c160)) {
+
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        } else {
+                            $this->checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e);
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_FOURDIGITYEAR:
+                    if (!empty($V2063c160)) {
+                        switch ($this->_result) {
+                            case 'timestamp':
+                                if ($this->checkTimeStampFormatFourDigitYear($V2063c160)) {
+                                    preg_match('#^([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{4})#', $V2063c160, $V9c28d32d);
+                                    $V7436f942 = $V9c28d32d[1];
+                                    $V628b7db0 = $V9c28d32d[2];
+                                    $V84cdc76c = $V9c28d32d[3];
+                                    if ($V84cdc76c < 1 || $V84cdc76c > 4000) {
+                                        $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                    } else
+                                    if (!checkdate($V7436f942, $V628b7db0, $V84cdc76c)) {
+                                        $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                    } else {
+                                        $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, false);
+                                    }
+                                } else {
+
+                                    $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                }
+                                break;
+                            default:
+                                preg_match('#([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{1,4})#', $V2063c160, $V78f0805f);
+                                if (count($V78f0805f) != 3) {
+                                    $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                } else {
+                                    $V6c8f3f79 = strlen($V78f0805f[2]);
+                                    if ($V6c8f3f79 != 4) {
+                                        $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                    } else {
+                                        if ($V78f0805f[2] < 1 || $V78f0805f[2] > 4000) {
+                                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                        } else {
+                                            if (!checkdate($V78f0805f[0], $V78f0805f[1], $V78f0805f[2])) {
+                                                $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                    break;
+                case FILEMAKER_RULE_TIMEOFDAY:
+                    if (!empty($V2063c160)) {
+                        if ($this->checkTimeFormat($V2063c160)) {
+                            $this->checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, true);
+                        } else {
+
+                            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                        }
+                    }
+                    break;
+            }
+        }
+        if ($V1c0c74f6) {
+            return $Vcb5e100e;
+        } else {
+            return $Vcb5e100e->numErrors() ? $Vcb5e100e : true;
+        }
+    }
+
+    public function getLocalValidationRules()
+    {
+        $V6b55d9ec = array();
+        foreach (array_keys($this->_validationRules) as $V981c1e7b) {
+            switch ($V981c1e7b) {
+                case FILEMAKER_RULE_NOTEMPTY:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_NUMERICONLY:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_MAXCHARACTERS:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_FOURDIGITYEAR:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_TIMEOFDAY:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_TIMESTAMP_FIELD:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_DATE_FIELD:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+                case FILEMAKER_RULE_TIME_FIELD:
+                    $V6b55d9ec[] = $V981c1e7b;
+                    break;
+            }
+        }
+        return $V6b55d9ec;
+    }
+    public function checkTimeStampFormatFourDigitYear($V2063c160)
+    {
+        return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})[-,/,\\\\]([0-9]{4})[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
+    }
+    public function checkTimeStampFormat($V2063c160)
+    {
+        return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
+    }
+    public function checkDateFormat($V2063c160)
+    {
+        return (preg_match('#^[ ]*([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?[ ]*$#', $V2063c160));
+    }
+    public function checkTimeFormat($V2063c160)
+    {
+        return (preg_match('#^[ ]*([0-9]{1,2})[:]([0-9]{1,2})([:][0-9]{1,2})?([ ]*((AM|PM)|(am|pm)))?[ ]*$#', $V2063c160));
+    }
+    public function checkNumericOnly($V2063c160)
+    {
+        return (!is_numeric($V2063c160));
+    }
+    public function checkDateValidity($V2063c160, $V981c1e7b, $Vcb5e100e)
+    {
+        preg_match('#([0-9]{1,2})[-,/,\\\\]([0-9]{1,2})([-,/,\\\\]([0-9]{1,4}))?#', $V2063c160, $V78f0805f);
+        if ($V78f0805f[4]) {
+            $V6c8f3f79 = strlen($V78f0805f[4]);
+            $V84cdc76c = $V78f0805f[4];
+            if ($V6c8f3f79 != 4) {
+                $V84cdc76c = $V84cdc76c + 2000;
+            }
+            if ($V78f0805f[4] < 1 || $V78f0805f[4] > 4000) {
+                $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+            } else {
+                if (!checkdate($V78f0805f[1], $V78f0805f[2], $V78f0805f[4])) {
+                    $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+                }
+            }
+        } else {
+            $V84cdc76c = date('Y');
+            if (!checkdate($V78f0805f[1], $V78f0805f[2], $V84cdc76c)) {
+                $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+            }
+        }
+    }
+    public function checkTimeValidity($V2063c160, $V981c1e7b, $Vcb5e100e, $Vcaf85b7b)
+    {
+        $V52124c01 = 0;
+        if ($Vcaf85b7b) {
+            $V52124c01 = 12;
+        } else {
+            $V52124c01 = 24;
+        }
+        preg_match('#([0-9]{1,2})[:]([0-9]{1,2})[:]?([0-9]{1,2})?#', $V2063c160, $V9c28d32d);
+        $V896c55cc = $V9c28d32d[1];
+        $V640fd0cc = $V9c28d32d[2];
+        if (count($V9c28d32d) >= 4) {
+            $V783e8e29 = $V9c28d32d[3];
+        }
+        if ($V896c55cc < 0 || $V896c55cc > $V52124c01) {
+            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+        } else if ($V640fd0cc < 0 || $V640fd0cc > 59) {
+            $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+        } else
+        if (isset($V783e8e29)) {
+            if ($V783e8e29 < 0 || $V783e8e29 > 59) {
+                $Vcb5e100e->addError($this, $V981c1e7b, $V2063c160);
+            }
+
+        }
+    }
+    public function getValidationRules()
+    {
+        return array_keys($this->_validationRules);
+    }
+    public function getValidationMask()
+    {
+        return $this->_validationMask;
+    }
+    public function hasValidationRule($Ve289cc97)
+    {
+        return $Ve289cc97 & $this->_validationMask;
+    }
+    public function describeValidationRule($Ve289cc97)
+    {
+        if (is_array($this->_validationRules[$Ve289cc97])) {
+            return $this->_validationRules[$Ve289cc97];
+        }
+        return null;
+    }
+    public function describeLocalValidationRules()
+    {
+        $V6b55d9ec = array();
+        foreach ($this->_validationRules as $V981c1e7b => $V1dee80c7) {
+            switch ($V981c1e7b) {
+                case FILEMAKER_RULE_NOTEMPTY:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_NUMERICONLY:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_MAXCHARACTERS:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_FOURDIGITYEAR:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_TIMEOFDAY:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_TIMESTAMP_FIELD:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_DATE_FIELD:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+                case FILEMAKER_RULE_TIME_FIELD:
+                    $V6b55d9ec[$V981c1e7b] = $V1dee80c7;
+                    break;
+            }
+        }
+        return $V6b55d9ec;
+    }
+    public function describeValidationRules()
+    {
+        return $this->_validationRules;
+    }
+    public function getResult()
+    {
+        return $this->_result;
+    }
+    public function getType()
+    {
+        return $this->_type;
+    }
+    public function getValueList($Vd33e904c = null)
+    {
+        $Vb4a88417 = $this->_layout->loadExtendedInfo($Vd33e904c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return $this->_layout->getValueList($this->_valueList);
+    }
+    public function getStyleType()
+    {
+        $Vb4a88417 = $this->_layout->loadExtendedInfo();
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return $this->_styleType;
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/FileMakerImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/FileMakerImpl.php
@@ -1,466 +1,451 @@
 <?php
-  require_once dirname(__FILE__) . '/Parser/FMResultSet.php';
- class FileMaker_Implementation
+require_once dirname(__FILE__) . '/Parser/FMResultSet.php';
+class FileMaker_Implementation
 {
-  var $V73ee434e = array('charset' => 'utf-8');
- var $Vea4b3413 = null;
+    public $V73ee434e = array('charset' => 'utf-8');
+    public $Vea4b3413 = null;
 
- var $V9a3dcbce;
- function getAPIVersion()
- {
- return '1.1';
-}
- static function getMinServerVersion()
- {
- return '10.0.0.0';
-}
- function FileMaker_Implementation($V11e0eed8, $Vccd0e374, $V14c4b06b, $V5f4dcc3b)
- {
- $V07cc694b = time();
-if ((@include dirname(__FILE__) . '/../conf/filemaker-api.php') && isset($__FM_CONFIG)) {
- foreach ($__FM_CONFIG as $V23a5b8ab => $V2063c160) {
- $this->setProperty($V23a5b8ab, $V2063c160);
-}
-}
-if (!is_null($Vccd0e374)) {
- $this->setProperty('hostspec', $Vccd0e374);
-}
-if (!is_null($V11e0eed8)) {
- $this->setProperty('database', $V11e0eed8);
-}
-if (!is_null($V14c4b06b)) {
- $this->setProperty('username', $V14c4b06b);
-}
-if (!is_null($V5f4dcc3b)) {
- $this->setProperty('password', $V5f4dcc3b);
-}
-}
- function setProperty($V23a5b8ab, $V2063c160)
- {
- $this->V73ee434e[$V23a5b8ab] = $V2063c160;
-}
- function getProperty($V23a5b8ab)
- {
- return isset($this->V73ee434e[$V23a5b8ab]) ? $this->V73ee434e[$V23a5b8ab] : null;
-}
- function getProperties()
- {
- return $this->V73ee434e;
-}
- function setLogger(&$V6db435f3)
- {
- if (!is_a($V6db435f3, 'Log')) {
- return new FileMaker_Error($this, 'setLogger() must be passed an instance of PEAR::Log');
-}
-$this->Vea4b3413=& $V6db435f3;
-}
- function log($V78e73102, $Vc9e9a848)
- {
- if ($this->Vea4b3413=== null) {
- return;
-}
-$Ve4aa4dcd = $this->getProperty('logLevel');
-if ($Ve4aa4dcd === null || $Vc9e9a848 > $Ve4aa4dcd) {
- return;
-}
-switch ($Vc9e9a848) {
- case FILEMAKER_LOG_DEBUG:
- $this->Vea4b3413->log($V78e73102, PEAR_LOG_DEBUG);
-break;
-case FILEMAKER_LOG_INFO:
- $this->Vea4b3413->log($V78e73102, PEAR_LOG_INFO);
-break;
-case FILEMAKER_LOG_ERR:
- $this->Vea4b3413->log($V78e73102, PEAR_LOG_ERR);
-break;
-}
-}
- function toOutputCharset($V1d770934)
- {
- if (strtolower($this->getProperty('charset')) != 'iso-8859-1') {
- return $V1d770934;
-}
-if (is_array($V1d770934)) {
- $Vfa816edb = array();
-foreach ($V1d770934 as $V3c6e0b8a => $V3a6d0284) {
- $Vfa816edb[$this->toOutputCharset($V3c6e0b8a)] = $this->toOutputCharset($V3a6d0284);
-}
-return $Vfa816edb;
-}
-if (!is_string($V1d770934)) {
- return $V1d770934;
-}
-return utf8_decode($V1d770934);
-}
- function &newAddCommand($Vc6140495, $Vf09cc7ee = array())
- {
- require_once dirname(__FILE__) . '/../Command/Add.php';
-$Vab4d0a65 = new FileMaker_Command_Add($this, $Vc6140495, $Vf09cc7ee);
-return $Vab4d0a65;
-}
- function &newEditCommand($Vc6140495, $Va6ec9c02, $Va0af1e2b = array())
- {
- require_once dirname(__FILE__) . '/../Command/Edit.php';
-$Vab4d0a65 = new FileMaker_Command_Edit($this, $Vc6140495, $Va6ec9c02, $Va0af1e2b);
-return $Vab4d0a65;
-}
- function &newDeleteCommand($Vc6140495, $Va6ec9c02)
- {
- require_once dirname(__FILE__) . '/../Command/Delete.php';
-$Vab4d0a65 = new FileMaker_Command_Delete($this, $Vc6140495, $Va6ec9c02);
-return $Vab4d0a65;
-}
- function &newDuplicateCommand($Vc6140495, $Va6ec9c02)
- {
- require_once dirname(__FILE__) . '/../Command/Duplicate.php';
-$Vab4d0a65 = new FileMaker_Command_Duplicate($this, $Vc6140495, $Va6ec9c02);
-return $Vab4d0a65;
-}
- function &newFindCommand($Vc6140495)
- {
- require_once dirname(__FILE__) . '/../Command/Find.php';
-$Vab4d0a65 = new FileMaker_Command_Find($this, $Vc6140495);
-return $Vab4d0a65;
-}
+    public $V9a3dcbce;
+    public function getAPIVersion()
+    {
+        return '1.1';
+    }
+    public static function getMinServerVersion()
+    {
+        return '10.0.0.0';
+    }
+    public function __construct($V11e0eed8, $Vccd0e374, $V14c4b06b, $V5f4dcc3b)
+    {
+        $V07cc694b = time();
+        if ((@include dirname(__FILE__) . '/../conf/filemaker-api.php') && isset($__FM_CONFIG)) {
+            foreach ($__FM_CONFIG as $V23a5b8ab => $V2063c160) {
+                $this->setProperty($V23a5b8ab, $V2063c160);
+            }
+        }
+        if (!is_null($Vccd0e374)) {
+            $this->setProperty('hostspec', $Vccd0e374);
+        }
+        if (!is_null($V11e0eed8)) {
+            $this->setProperty('database', $V11e0eed8);
+        }
+        if (!is_null($V14c4b06b)) {
+            $this->setProperty('username', $V14c4b06b);
+        }
+        if (!is_null($V5f4dcc3b)) {
+            $this->setProperty('password', $V5f4dcc3b);
+        }
+    }
+    public function setProperty($V23a5b8ab, $V2063c160)
+    {
+        $this->V73ee434e[$V23a5b8ab] = $V2063c160;
+    }
+    public function getProperty($V23a5b8ab)
+    {
+        return isset($this->V73ee434e[$V23a5b8ab]) ? $this->V73ee434e[$V23a5b8ab] : null;
+    }
+    public function getProperties()
+    {
+        return $this->V73ee434e;
+    }
+    public function setLogger(&$V6db435f3)
+    {
+        if (!is_a($V6db435f3, 'Log')) {
+            return new FileMaker_Error($this, 'setLogger() must be passed an instance of PEAR::Log');
+        }
+        $this->Vea4b3413 = &$V6db435f3;
+    }
+    public function log($V78e73102, $Vc9e9a848)
+    {
+        if ($this->Vea4b3413 === null) {
+            return;
+        }
+        $Ve4aa4dcd = $this->getProperty('logLevel');
+        if ($Ve4aa4dcd === null || $Vc9e9a848 > $Ve4aa4dcd) {
+            return;
+        }
+        switch ($Vc9e9a848) {
+            case FILEMAKER_LOG_DEBUG:
+                $this->Vea4b3413->log($V78e73102, PEAR_LOG_DEBUG);
+                break;
+            case FILEMAKER_LOG_INFO:
+                $this->Vea4b3413->log($V78e73102, PEAR_LOG_INFO);
+                break;
+            case FILEMAKER_LOG_ERR:
+                $this->Vea4b3413->log($V78e73102, PEAR_LOG_ERR);
+                break;
+        }
+    }
+    public function toOutputCharset($V1d770934)
+    {
+        if (strtolower($this->getProperty('charset')) != 'iso-8859-1') {
+            return $V1d770934;
+        }
+        if (is_array($V1d770934)) {
+            $Vfa816edb = array();
+            foreach ($V1d770934 as $V3c6e0b8a => $V3a6d0284) {
+                $Vfa816edb[$this->toOutputCharset($V3c6e0b8a)] = $this->toOutputCharset($V3a6d0284);
+            }
+            return $Vfa816edb;
+        }
+        if (!is_string($V1d770934)) {
+            return $V1d770934;
+        }
+        return utf8_decode($V1d770934);
+    }
+    public function &newAddCommand($Vc6140495, $Vf09cc7ee = array())
+    {
+        require_once dirname(__FILE__) . '/../Command/Add.php';
+        $Vab4d0a65 = new FileMaker_Command_Add($this, $Vc6140495, $Vf09cc7ee);
+        return $Vab4d0a65;
+    }
+    public function &newEditCommand($Vc6140495, $Va6ec9c02, $Va0af1e2b = array())
+    {
+        require_once dirname(__FILE__) . '/../Command/Edit.php';
+        $Vab4d0a65 = new FileMaker_Command_Edit($this, $Vc6140495, $Va6ec9c02, $Va0af1e2b);
+        return $Vab4d0a65;
+    }
+    public function &newDeleteCommand($Vc6140495, $Va6ec9c02)
+    {
+        require_once dirname(__FILE__) . '/../Command/Delete.php';
+        $Vab4d0a65 = new FileMaker_Command_Delete($this, $Vc6140495, $Va6ec9c02);
+        return $Vab4d0a65;
+    }
+    public function &newDuplicateCommand($Vc6140495, $Va6ec9c02)
+    {
+        require_once dirname(__FILE__) . '/../Command/Duplicate.php';
+        $Vab4d0a65 = new FileMaker_Command_Duplicate($this, $Vc6140495, $Va6ec9c02);
+        return $Vab4d0a65;
+    }
+    public function &newFindCommand($Vc6140495)
+    {
+        require_once dirname(__FILE__) . '/../Command/Find.php';
+        $Vab4d0a65 = new FileMaker_Command_Find($this, $Vc6140495);
+        return $Vab4d0a65;
+    }
 
-  function &newCompoundFindCommand($Vc6140495)
- {
- require_once dirname(__FILE__) . '/../Command/CompoundFind.php';
-$Vcdaeeeba = new FileMaker_Command_CompoundFind($this, $Vc6140495);
-return $Vcdaeeeba;
+    public function &newCompoundFindCommand($Vc6140495)
+    {
+        require_once dirname(__FILE__) . '/../Command/CompoundFind.php';
+        $Vcdaeeeba = new FileMaker_Command_CompoundFind($this, $Vc6140495);
+        return $Vcdaeeeba;
 
- }
+    }
 
-  function &newFindRequest($Vc6140495)
- {
- require_once dirname(__FILE__) . '/../Command/FindRequest.php';
-$Vab4d0a65 = new FileMaker_Command_FindRequest($this, $Vc6140495);
-return $Vab4d0a65;
+    public function &newFindRequest($Vc6140495)
+    {
+        require_once dirname(__FILE__) . '/../Command/FindRequest.php';
+        $Vab4d0a65 = new FileMaker_Command_FindRequest($this, $Vc6140495);
+        return $Vab4d0a65;
 
- }
+    }
 
-  function &newFindAnyCommand($Vc6140495)
- {
- require_once dirname(__FILE__) . '/../Command/FindAny.php';
-$Vab4d0a65 = new FileMaker_Command_FindAny($this, $Vc6140495);
-return $Vab4d0a65;
-}
- function &newFindAllCommand($Vc6140495)
- {
- require_once dirname(__FILE__) . '/../Command/FindAll.php';
-$Vab4d0a65 = new FileMaker_Command_FindAll($this, $Vc6140495);
-return $Vab4d0a65;
-}
- function &newPerformScriptCommand($Vc6140495, $V2550889a, $V9b479e5e = null)
- {
- require_once dirname(__FILE__) . '/../Command/PerformScript.php';
-$Vab4d0a65 = new FileMaker_Command_PerformScript($this, $Vc6140495, $V2550889a, $V9b479e5e);
-return $Vab4d0a65;
-}
- function &createRecord($Vf43ac2d2, $Vfe0f78a8 = array())
- {
- $Vc6140495 =& $this->getLayout($Vf43ac2d2);
-if (FileMaker::isError($Vc6140495)) {
- return $Vc6140495;
-}
-$Vde17f0f2 = new $this->V73ee434e['recordClass']($Vc6140495);
-if (is_array($Vfe0f78a8)) {
- foreach ($Vfe0f78a8 as $V3c6e0b8a => $V2063c160) {
- if (is_array($V2063c160)) {
- foreach ($V2063c160 as $V6d786dc7 => $Vb5528fe6) {
- $Vde17f0f2->setField($V3c6e0b8a, $Vb5528fe6, $V6d786dc7);
-}
-} else {
- $Vde17f0f2->setField($V3c6e0b8a, $V2063c160);
-}
-}
-}
-return $Vde17f0f2;
-}
- function &getRecordById($Vc6140495, $Va6ec9c02)
- {
- $V10573b87 =& $this->newFindCommand($Vc6140495);
-$V10573b87->setRecordId($Va6ec9c02);
-$Vd1fc8eaf = $V10573b87->execute();
-if (FileMaker::isError($Vd1fc8eaf)) {
- return $Vd1fc8eaf;
-}
-$V6e52c40b =& $Vd1fc8eaf->getRecords();
-if (!$V6e52c40b) {
- $Vcb5e100e = new FileMaker_Error($this, 'Record . ' . $Va6ec9c02 . ' not found in layout "' . $Vc6140495 . '".');
-return $Vcb5e100e;
-}
-return $V6e52c40b[0];
-}
- function &getLayout($Vf43ac2d2)
- { 
- static $V34d59fda = array();
-if (isset($V34d59fda[$Vf43ac2d2])) {
- return $V34d59fda[$Vf43ac2d2];
-}
-$V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
- '-lay' => $Vf43ac2d2,
- '-view' => true));
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-}
-$V3643b863 = new FileMaker_Parser_FMResultSet($this);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$Vc6140495 = new FileMaker_Layout($this);
-$Vb4a88417 = $V3643b863->setLayout($Vc6140495);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$V34d59fda[$Vf43ac2d2] =& $Vc6140495;
-return $Vc6140495;
-}
- function listDatabases()
- {
- $V0f635d0e = $this->_execute(array('-dbnames' => true));
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-}
-$V3643b863 = new FileMaker_Parser_fmresultset($this);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$Ve61ce306 = array();
-foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
- $Ve61ce306[] = $V0b2c082c['fields']['DATABASE_NAME'][0];
-}
-return $Ve61ce306;
-}
- function listScripts()
- {
- $V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
- '-scriptnames' => true));
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-}
-$V3643b863 = new FileMaker_Parser_FMResultSet($this);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$Vd6c5855a = array();
-foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
- $Vd6c5855a[] = $V0b2c082c['fields']['SCRIPT_NAME'][0];
-}
-return $Vd6c5855a;
-}
- function listLayouts()
- {
- $V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
- '-layoutnames' => true));
-if (FileMaker::isError($V0f635d0e)) {
- return $V0f635d0e;
-}
-$V3643b863 = new FileMaker_Parser_FMResultSet($this);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$V34d59fda = array();
-foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
- $V34d59fda[] = $V0b2c082c['fields']['LAYOUT_NAME'][0];
-}
-return $V34d59fda;
-}
- function getContainerData($V9305b73d)
- { 
- if (!function_exists('curl_init')) {
- return new FileMaker_Error($this, 'cURL is required to use the FileMaker API.');
-}
- if (strncasecmp($V9305b73d, '/fmi/xml/cnt', 11) != 0) {
- return new FileMaker_Error($this, 'getContainerData() does not support remote containers');
-}
-else {
-$V572d4e42 = $this->getProperty('hostspec');
-if (substr($V572d4e42, -1, 1) == '/') {
- $V572d4e42 = substr($V572d4e42, 0, -1);
-}
-$V572d4e42 .= $V9305b73d; 
- $V572d4e42 = htmlspecialchars_decode($V572d4e42); 
- $V572d4e42 = str_replace(" ", "%20", $V572d4e42);
-}
- $this->log('Request for ' . $V572d4e42, FILEMAKER_LOG_INFO); 
- $Vd88fc6ed = curl_init($V572d4e42);
+    public function &newFindAnyCommand($Vc6140495)
+    {
+        require_once dirname(__FILE__) . '/../Command/FindAny.php';
+        $Vab4d0a65 = new FileMaker_Command_FindAny($this, $Vc6140495);
+        return $Vab4d0a65;
+    }
+    public function &newFindAllCommand($Vc6140495)
+    {
+        require_once dirname(__FILE__) . '/../Command/FindAll.php';
+        $Vab4d0a65 = new FileMaker_Command_FindAll($this, $Vc6140495);
+        return $Vab4d0a65;
+    }
+    public function &newPerformScriptCommand($Vc6140495, $V2550889a, $V9b479e5e = null)
+    {
+        require_once dirname(__FILE__) . '/../Command/PerformScript.php';
+        $Vab4d0a65 = new FileMaker_Command_PerformScript($this, $Vc6140495, $V2550889a, $V9b479e5e);
+        return $Vab4d0a65;
+    }
+    public function &createRecord($Vf43ac2d2, $Vfe0f78a8 = array())
+    {
+        $Vc6140495 = &$this->getLayout($Vf43ac2d2);
+        if (FileMaker::isError($Vc6140495)) {
+            return $Vc6140495;
+        }
+        $Vde17f0f2 = new $this->V73ee434e['recordClass']($Vc6140495);
+        if (is_array($Vfe0f78a8)) {
+            foreach ($Vfe0f78a8 as $V3c6e0b8a => $V2063c160) {
+                if (is_array($V2063c160)) {
+                    foreach ($V2063c160 as $V6d786dc7 => $Vb5528fe6) {
+                        $Vde17f0f2->setField($V3c6e0b8a, $Vb5528fe6, $V6d786dc7);
+                    }
+                } else {
+                    $Vde17f0f2->setField($V3c6e0b8a, $V2063c160);
+                }
+            }
+        }
+        return $Vde17f0f2;
+    }
+    public function &getRecordById($Vc6140495, $Va6ec9c02)
+    {
+        $V10573b87 = &$this->newFindCommand($Vc6140495);
+        $V10573b87->setRecordId($Va6ec9c02);
+        $Vd1fc8eaf = $V10573b87->execute();
+        if (FileMaker::isError($Vd1fc8eaf)) {
+            return $Vd1fc8eaf;
+        }
+        $V6e52c40b = &$Vd1fc8eaf->getRecords();
+        if (!$V6e52c40b) {
+            $Vcb5e100e = new FileMaker_Error($this, 'Record . ' . $Va6ec9c02 . ' not found in layout "' . $Vc6140495 . '".');
+            return $Vcb5e100e;
+        }
+        return $V6e52c40b[0];
+    }
+    public function &getLayout($Vf43ac2d2)
+    {
+        static $V34d59fda = array();
+        if (isset($V34d59fda[$Vf43ac2d2])) {
+            return $V34d59fda[$Vf43ac2d2];
+        }
+        $V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
+            '-lay' => $Vf43ac2d2,
+            '-view' => true));
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        $V3643b863 = new FileMaker_Parser_FMResultSet($this);
+        $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $Vc6140495 = new FileMaker_Layout($this);
+        $Vb4a88417 = $V3643b863->setLayout($Vc6140495);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $V34d59fda[$Vf43ac2d2] = &$Vc6140495;
+        return $Vc6140495;
+    }
+    public function listDatabases()
+    {
+        $V0f635d0e = $this->_execute(array('-dbnames' => true));
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        $V3643b863 = new FileMaker_Parser_fmresultset($this);
+        $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $Ve61ce306 = array();
+        foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
+            $Ve61ce306[] = $V0b2c082c['fields']['DATABASE_NAME'][0];
+        }
+        return $Ve61ce306;
+    }
+    public function listScripts()
+    {
+        $V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
+            '-scriptnames' => true));
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        $V3643b863 = new FileMaker_Parser_FMResultSet($this);
+        $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $Vd6c5855a = array();
+        foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
+            $Vd6c5855a[] = $V0b2c082c['fields']['SCRIPT_NAME'][0];
+        }
+        return $Vd6c5855a;
+    }
+    public function listLayouts()
+    {
+        $V0f635d0e = $this->_execute(array('-db' => $this->getProperty('database'),
+            '-layoutnames' => true));
+        if (FileMaker::isError($V0f635d0e)) {
+            return $V0f635d0e;
+        }
+        $V3643b863 = new FileMaker_Parser_FMResultSet($this);
+        $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        $V34d59fda = array();
+        foreach ($V3643b863->V6e52c40b as $V0b2c082c) {
+            $V34d59fda[] = $V0b2c082c['fields']['LAYOUT_NAME'][0];
+        }
+        return $V34d59fda;
+    }
+    public function getContainerData($V9305b73d)
+    {
+        if (!function_exists('curl_init')) {
+            return new FileMaker_Error($this, 'cURL is required to use the FileMaker API.');
+        }
+        if (strncasecmp($V9305b73d, '/fmi/xml/cnt', 11) != 0) {
+            return new FileMaker_Error($this, 'getContainerData() does not support remote containers');
+        } else {
+            $V572d4e42 = $this->getProperty('hostspec');
+            if (substr($V572d4e42, -1, 1) == '/') {
+                $V572d4e42 = substr($V572d4e42, 0, -1);
+            }
+            $V572d4e42 .= $V9305b73d;
+            $V572d4e42 = htmlspecialchars_decode($V572d4e42);
+            $V572d4e42 = str_replace(" ", "%20", $V572d4e42);
+        }
+        $this->log('Request for ' . $V572d4e42, FILEMAKER_LOG_INFO);
+        $Vd88fc6ed = curl_init($V572d4e42);
 
- curl_setopt($Vd88fc6ed, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($Vd88fc6ed, CURLOPT_FAILONERROR, true);
-$V81c939b1 = FALSE;
-if (!headers_sent())
-{
-$V81c939b1 = TRUE;
-curl_setopt($Vd88fc6ed, CURLOPT_HEADER, true);
-}
-$this->_setCurlWPCSessionCookie($Vd88fc6ed); 
-	
- if ($this->getProperty('username')) { 
- $V313225f0 = base64_encode($this->getProperty('username'). ':' . $this->getProperty('password'));
-$V44914468 = array('Authorization: Basic ' . $V313225f0, 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw==');
-curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, $V44914468);
-}
-else {
- curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw=='));
-}     
- if ($V93da65a9 = $this->getProperty('curlOptions')) {
- foreach ($V93da65a9 as $Vef3e30e0 => $V2063c160) {
- curl_setopt($Vd88fc6ed, $Vef3e30e0, $V2063c160);
-}
-}  
- $Vd1fc8eaf = curl_exec($Vd88fc6ed);
-$this->_setClientWPCSessionCookie($Vd1fc8eaf);
-if ($V81c939b1)
-{		
-$Vd1fc8eaf = $this->_eliminateContainerHeader($Vd1fc8eaf); 
-}
- $this->log($Vd1fc8eaf, FILEMAKER_LOG_DEBUG); 
- if ($V70106d0d = curl_errno($Vd88fc6ed)) {
- return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed));
-}
-curl_close($Vd88fc6ed);
-return $Vd1fc8eaf;
-}
- function _execute($Vf7cc8e48, $Vb3d1bd6a = 'fmresultset')
- { 
- if (!function_exists('curl_init')) {
- return new FileMaker_Error($this, 'cURL is required to use the FileMaker API.');
-} 
- $Ve0c6dcf8 = array();
-foreach ($Vf7cc8e48 as $V3c6e0b8a => $V3a6d0284) {
- if (strtolower($this->getProperty('charset')) != 'utf-8' && $V3a6d0284 !== true) {
- $V3a6d0284 = utf8_encode($V3a6d0284);
-}
-$Ve0c6dcf8[] = urlencode($V3c6e0b8a) . ($V3a6d0284 === true ? '' : '=' . urlencode($V3a6d0284));
-} 
- $V572d4e42 = $this->getProperty('hostspec');
-if (substr($V572d4e42, -1, 1) != '/') {
- $V572d4e42 .= '/';
-}
-$V572d4e42 .= 'fmi/xml/' . $Vb3d1bd6a . '.xml'; 
- $this->log('Request for ' . $V572d4e42, FILEMAKER_LOG_INFO); 
- $Vd88fc6ed = curl_init($V572d4e42);
-curl_setopt($Vd88fc6ed, CURLOPT_POST, true);
-curl_setopt($Vd88fc6ed, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($Vd88fc6ed, CURLOPT_FAILONERROR, true);
-$V81c939b1 = FALSE;
-if (!headers_sent())
-{
-$V81c939b1 = TRUE;
-curl_setopt($Vd88fc6ed, CURLOPT_HEADER, true);
-}
-$this->_setCurlWPCSessionCookie($Vd88fc6ed); 
-	
- if ($this->getProperty('username')) { 
- $V313225f0 = base64_encode(utf8_decode($this->getProperty('username')). ':' . utf8_decode($this->getProperty('password')));
-$V44914468 = 'Authorization: Basic ' . $V313225f0;
-curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded; charset=utf-8', 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw==', $V44914468));
-}else{
- curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded; charset=utf-8', 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw=='));
-}
+        curl_setopt($Vd88fc6ed, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($Vd88fc6ed, CURLOPT_FAILONERROR, true);
+        $V81c939b1 = false;
+        if (!headers_sent()) {
+            $V81c939b1 = true;
+            curl_setopt($Vd88fc6ed, CURLOPT_HEADER, true);
+        }
+        $this->_setCurlWPCSessionCookie($Vd88fc6ed);
 
- curl_setopt($Vd88fc6ed, CURLOPT_POSTFIELDS, implode('&', $Ve0c6dcf8));     
- if ($V93da65a9 = $this->getProperty('curlOptions')) {
- foreach ($V93da65a9 as $Vef3e30e0 => $V2063c160) {
- curl_setopt($Vd88fc6ed, $Vef3e30e0, $V2063c160);
-}
-}  
- $Vd1fc8eaf = curl_exec($Vd88fc6ed);
-$this->_setClientWPCSessionCookie($Vd1fc8eaf);
-if ($V81c939b1)
-{		
-$Vd1fc8eaf = $this->_eliminateXMLHeader($Vd1fc8eaf); 
-}
- $this->log($Vd1fc8eaf, FILEMAKER_LOG_DEBUG); 
- if ($V70106d0d = curl_errno($Vd88fc6ed)) {
- 
- if($V70106d0d == 52){
- return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - The Web Publishing Core and/or FileMaker Server services are not running.', $V70106d0d);
-}else if($V70106d0d == 22){	
- if (stristr("50", curl_error($Vd88fc6ed))) {
- return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - The Web Publishing Core and/or FileMaker Server services are not running.', $V70106d0d);
-}else{
- return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - This can be due to an invalid username or password, or if the FMPHP privilege is not enabled for that user.', $V70106d0d);
-}
-}else{
- return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed), $V70106d0d);
-}
-}
-curl_close($Vd88fc6ed);
+        if ($this->getProperty('username')) {
+            $V313225f0 = base64_encode($this->getProperty('username') . ':' . $this->getProperty('password'));
+            $V44914468 = array('Authorization: Basic ' . $V313225f0, 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw==');
+            curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, $V44914468);
+        } else {
+            curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw=='));
+        }
+        if ($V93da65a9 = $this->getProperty('curlOptions')) {
+            foreach ($V93da65a9 as $Vef3e30e0 => $V2063c160) {
+                curl_setopt($Vd88fc6ed, $Vef3e30e0, $V2063c160);
+            }
+        }
+        $Vd1fc8eaf = curl_exec($Vd88fc6ed);
+        $this->_setClientWPCSessionCookie($Vd1fc8eaf);
+        if ($V81c939b1) {
+            $Vd1fc8eaf = $this->_eliminateContainerHeader($Vd1fc8eaf);
+        }
+        $this->log($Vd1fc8eaf, FILEMAKER_LOG_DEBUG);
+        if ($V70106d0d = curl_errno($Vd88fc6ed)) {
+            return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed));
+        }
+        curl_close($Vd88fc6ed);
+        return $Vd1fc8eaf;
+    }
+    public function _execute($Vf7cc8e48, $Vb3d1bd6a = 'fmresultset')
+    {
+        if (!function_exists('curl_init')) {
+            return new FileMaker_Error($this, 'cURL is required to use the FileMaker API.');
+        }
+        $Ve0c6dcf8 = array();
+        foreach ($Vf7cc8e48 as $V3c6e0b8a => $V3a6d0284) {
+            if (strtolower($this->getProperty('charset')) != 'utf-8' && $V3a6d0284 !== true) {
+                $V3a6d0284 = utf8_encode($V3a6d0284);
+            }
+            $Ve0c6dcf8[] = urlencode($V3c6e0b8a) . ($V3a6d0284 === true ? '' : '=' . urlencode($V3a6d0284));
+        }
+        $V572d4e42 = $this->getProperty('hostspec');
+        if (substr($V572d4e42, -1, 1) != '/') {
+            $V572d4e42 .= '/';
+        }
+        $V572d4e42 .= 'fmi/xml/' . $Vb3d1bd6a . '.xml';
+        $this->log('Request for ' . $V572d4e42, FILEMAKER_LOG_INFO);
+        $Vd88fc6ed = curl_init($V572d4e42);
+        curl_setopt($Vd88fc6ed, CURLOPT_POST, true);
+        curl_setopt($Vd88fc6ed, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($Vd88fc6ed, CURLOPT_FAILONERROR, true);
+        $V81c939b1 = false;
+        if (!headers_sent()) {
+            $V81c939b1 = true;
+            curl_setopt($Vd88fc6ed, CURLOPT_HEADER, true);
+        }
+        $this->_setCurlWPCSessionCookie($Vd88fc6ed);
 
- return $Vd1fc8eaf;
-}
-function getContainerDataURL($V781b3578)
-{
-if (strncasecmp($V781b3578, '/fmi/xml/cnt', 11) != 0) {
-$Va351dce6 = htmlspecialchars_decode($V781b3578);
-}
-else {
-$Va351dce6 = $this->getProperty('hostspec');
-if (substr($Va351dce6, -1, 1) == '/') {
-$Va351dce6 = substr($Va351dce6, 0, -1);
-}
-$Va351dce6 .= $V781b3578;
-$Va351dce6 = htmlspecialchars_decode($Va351dce6);
-}
-return $Va351dce6;
-}
-function _setCurlWPCSessionCookie($Vd88fc6ed)
- {
- if (isset($_COOKIE["WPCSessionID"])) {
- $Vd06f6e6e = $_COOKIE["WPCSessionID"]; 
- if (!is_null($Vd06f6e6e)) {
- $V0fbf52c7 = "WPCSessionID=".$Vd06f6e6e;
-curl_setopt($Vd88fc6ed, CURLOPT_COOKIE, $V0fbf52c7);
-}
-}
-}
-function _setClientWPCSessionCookie($Vd1fc8eaf)
- {
- $V81c939b1 = preg_match('/WPCSessionID=(\d+?);/m', $Vd1fc8eaf, $V6da3345e);
-if ($V81c939b1) {
- setcookie("WPCSessionID", $V6da3345e[1]);
-}
-}
-function _getContentLength($Vd1fc8eaf)
-{
-$V81c939b1 = preg_match('/Content-Length: (\d+)/', $Vd1fc8eaf, $V6da3345e);
-if ($V81c939b1) {
-return $V6da3345e[1];
-}
-else
-{
-return -1;
-}
-}
-function _eliminateXMLHeader($Vd1fc8eaf)
-{
-$V81c939b1 = strpos($Vd1fc8eaf, "<?xml");
-if ($V81c939b1 !== false)
-{
-return substr($Vd1fc8eaf, $V81c939b1);
-}
-else
-{
-return $Vd1fc8eaf;
-}
-}
-function _eliminateContainerHeader($Vd1fc8eaf)
-{
-$V04d77ddd = strlen("\r\n\r\n");
-$V81c939b1 = strpos($Vd1fc8eaf, "\r\n\r\n");
-if ($V81c939b1 !== false)
-{
-return substr($Vd1fc8eaf, $V81c939b1+$V04d77ddd);
-}
-else
-{
-return $Vd1fc8eaf;
-} 
-}
+        if ($this->getProperty('username')) {
+            $V313225f0 = base64_encode(utf8_decode($this->getProperty('username')) . ':' . utf8_decode($this->getProperty('password')));
+            $V44914468 = 'Authorization: Basic ' . $V313225f0;
+            curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded; charset=utf-8', 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw==', $V44914468));
+        } else {
+            curl_setopt($Vd88fc6ed, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded; charset=utf-8', 'X-FMI-PE-ExtendedPrivilege: IrG6U+Rx0F5bLIQCUb9gOw=='));
+        }
+
+        curl_setopt($Vd88fc6ed, CURLOPT_POSTFIELDS, implode('&', $Ve0c6dcf8));
+        if ($V93da65a9 = $this->getProperty('curlOptions')) {
+            foreach ($V93da65a9 as $Vef3e30e0 => $V2063c160) {
+                curl_setopt($Vd88fc6ed, $Vef3e30e0, $V2063c160);
+            }
+        }
+        $Vd1fc8eaf = curl_exec($Vd88fc6ed);
+        $this->_setClientWPCSessionCookie($Vd1fc8eaf);
+        if ($V81c939b1) {
+            $Vd1fc8eaf = $this->_eliminateXMLHeader($Vd1fc8eaf);
+        }
+        $this->log($Vd1fc8eaf, FILEMAKER_LOG_DEBUG);
+        if ($V70106d0d = curl_errno($Vd88fc6ed)) {
+
+            if ($V70106d0d == 52) {
+                return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - The Web Publishing Core and/or FileMaker Server services are not running.', $V70106d0d);
+            } else if ($V70106d0d == 22) {
+                if (stristr("50", curl_error($Vd88fc6ed))) {
+                    return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - The Web Publishing Core and/or FileMaker Server services are not running.', $V70106d0d);
+                } else {
+                    return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed) . ' - This can be due to an invalid username or password, or if the FMPHP privilege is not enabled for that user.', $V70106d0d);
+                }
+            } else {
+                return new FileMaker_Error($this, 'Communication Error: (' . $V70106d0d . ') ' . curl_error($Vd88fc6ed), $V70106d0d);
+            }
+        }
+        curl_close($Vd88fc6ed);
+
+        return $Vd1fc8eaf;
+    }
+    public function getContainerDataURL($V781b3578)
+    {
+        if (strncasecmp($V781b3578, '/fmi/xml/cnt', 11) != 0) {
+            $Va351dce6 = htmlspecialchars_decode($V781b3578);
+        } else {
+            $Va351dce6 = $this->getProperty('hostspec');
+            if (substr($Va351dce6, -1, 1) == '/') {
+                $Va351dce6 = substr($Va351dce6, 0, -1);
+            }
+            $Va351dce6 .= $V781b3578;
+            $Va351dce6 = htmlspecialchars_decode($Va351dce6);
+        }
+        return $Va351dce6;
+    }
+    public function _setCurlWPCSessionCookie($Vd88fc6ed)
+    {
+        if (isset($_COOKIE["WPCSessionID"])) {
+            $Vd06f6e6e = $_COOKIE["WPCSessionID"];
+            if (!is_null($Vd06f6e6e)) {
+                $V0fbf52c7 = "WPCSessionID=" . $Vd06f6e6e;
+                curl_setopt($Vd88fc6ed, CURLOPT_COOKIE, $V0fbf52c7);
+            }
+        }
+    }
+    public function _setClientWPCSessionCookie($Vd1fc8eaf)
+    {
+        $V81c939b1 = preg_match('/WPCSessionID=(\d+?);/m', $Vd1fc8eaf, $V6da3345e);
+        if ($V81c939b1) {
+            setcookie("WPCSessionID", $V6da3345e[1]);
+        }
+    }
+    public function _getContentLength($Vd1fc8eaf)
+    {
+        $V81c939b1 = preg_match('/Content-Length: (\d+)/', $Vd1fc8eaf, $V6da3345e);
+        if ($V81c939b1) {
+            return $V6da3345e[1];
+        } else {
+            return -1;
+        }
+    }
+    public function _eliminateXMLHeader($Vd1fc8eaf)
+    {
+        $V81c939b1 = strpos($Vd1fc8eaf, "<?xml");
+        if ($V81c939b1 !== false) {
+            return substr($Vd1fc8eaf, $V81c939b1);
+        } else {
+            return $Vd1fc8eaf;
+        }
+    }
+    public function _eliminateContainerHeader($Vd1fc8eaf)
+    {
+        $V04d77ddd = strlen("\r\n\r\n");
+        $V81c939b1 = strpos($Vd1fc8eaf, "\r\n\r\n");
+        if ($V81c939b1 !== false) {
+            return substr($Vd1fc8eaf, $V81c939b1 + $V04d77ddd);
+        } else {
+            return $Vd1fc8eaf;
+        }
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/LayoutImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/LayoutImpl.php
@@ -1,131 +1,130 @@
 <?php
-  require_once dirname(__FILE__) . '/../Field.php';
+require_once dirname(__FILE__) . '/../Field.php';
 require_once dirname(__FILE__) . '/Parser/FMPXMLLAYOUT.php';
- class FileMaker_Layout_Implementation
+class FileMaker_Layout_Implementation
 {
-  var $_fm;
- var $_name;
- var $_fields = array();
- var $_relatedSets = array();
- var $_valueLists = array();
+    public $_fm;
+    public $_name;
+    public $_fields = array();
+    public $_relatedSets = array();
+    public $_valueLists = array();
 
-	 
- var $Vab234ad8 = array();
- var $_database;
- var $_extended = false;
- function FileMaker_Layout_Implementation(&$V0ab34ca9)
- {
- $this->_fm =& $V0ab34ca9;
-}
- function getName()
- {
- return $this->_name;
-}
- function getDatabase()
- {
- return $this->_database;
-}
- function listFields()
- {
- return array_keys($this->_fields);
-}
- function getField($V972bf3f0)
- {
- if (isset($this->_fields[$V972bf3f0])) {
- return $this->_fields[$V972bf3f0];
-}
-return $Vcb5e100e = new FileMaker_Error($this->_fm, 'Field Not Found');
-}
- function &getFields()
- {
- return $this->_fields;
-}
- function listRelatedSets()
- {
- return array_keys($this->_relatedSets);
-}
- function &getRelatedSet($Vaca007a7)
- {
- if (isset($this->_relatedSets[$Vaca007a7])) {
- return $this->_relatedSets[$Vaca007a7];
-}
-return $Vcb5e100e = new FileMaker_Error($this->_fm, 'RelatedSet Not Found');
-}
- function &getRelatedSets()
- {
- return $this->_relatedSets;
-}
- function listValueLists()
- {
- $Vb4a88417 = $this->loadExtendedInfo();
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return array_keys($this->_valueLists);
-}
- 
- function getValueListTwoFields($V993fcb1e, $Vd33e904c = null){
- 
- $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return isset($this->_valueLists[$V993fcb1e]) ?
- $this->Vab234ad8[$V993fcb1e] : null;
-}
+    public $Vab234ad8 = array();
+    public $_database;
+    public $_extended = false;
+    public function __construct(&$V0ab34ca9)
+    {
+        $this->_fm = &$V0ab34ca9;
+    }
+    public function getName()
+    {
+        return $this->_name;
+    }
+    public function getDatabase()
+    {
+        return $this->_database;
+    }
+    public function listFields()
+    {
+        return array_keys($this->_fields);
+    }
+    public function getField($V972bf3f0)
+    {
+        if (isset($this->_fields[$V972bf3f0])) {
+            return $this->_fields[$V972bf3f0];
+        }
+        return $Vcb5e100e = new FileMaker_Error($this->_fm, 'Field Not Found');
+    }
+    public function &getFields()
+    {
+        return $this->_fields;
+    }
+    public function listRelatedSets()
+    {
+        return array_keys($this->_relatedSets);
+    }
+    public function &getRelatedSet($Vaca007a7)
+    {
+        if (isset($this->_relatedSets[$Vaca007a7])) {
+            return $this->_relatedSets[$Vaca007a7];
+        }
+        return $Vcb5e100e = new FileMaker_Error($this->_fm, 'RelatedSet Not Found');
+    }
+    public function &getRelatedSets()
+    {
+        return $this->_relatedSets;
+    }
+    public function listValueLists()
+    {
+        $Vb4a88417 = $this->loadExtendedInfo();
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return array_keys($this->_valueLists);
+    }
 
-  function getValueList($V993fcb1e, $Vd33e904c = null)
- {
- $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return isset($this->_valueLists[$V993fcb1e]) ?
- $this->_valueLists[$V993fcb1e] : null;
-}
+    public function getValueListTwoFields($V993fcb1e, $Vd33e904c = null)
+    {
 
-  
- function getValueListsTwoFields($Vd33e904c = null)
- {
- $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return $this->Vab234ad8;
-}
- function getValueLists($Vd33e904c = null)
- {
- $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-return $this->_valueLists;
-}
- function loadExtendedInfo($Vd33e904c = null)
- {
- if (!$this->_extended) {
- 
- if($Vd33e904c != null){
- $V0f635d0e = $this->_fm->_execute(array('-db' => $this->_fm->getProperty('database'),
- '-lay' => $this->getName(),
- '-recid' => $Vd33e904c,
- '-view' => null),
- 'FMPXMLLAYOUT');
-}else{
- $V0f635d0e = $this->_fm->_execute(array('-db' => $this->_fm->getProperty('database'),
- '-lay' => $this->getName(),
- '-view' => null),
- 'FMPXMLLAYOUT');
+        $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return isset($this->_valueLists[$V993fcb1e]) ?
+        $this->Vab234ad8[$V993fcb1e] : null;
+    }
 
- }
-$V3643b863 = new FileMaker_Parser_FMPXMLLAYOUT($this->_fm);
-$Vb4a88417 = $V3643b863->parse($V0f635d0e);
-if (FileMaker::isError($Vb4a88417)) {
- return $Vb4a88417;
-}
-$V3643b863->setExtendedInfo($this);
-$this->_extended = true;
-}
-return $this->_extended;
-}
+    public function getValueList($V993fcb1e, $Vd33e904c = null)
+    {
+        $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return isset($this->_valueLists[$V993fcb1e]) ?
+        $this->_valueLists[$V993fcb1e] : null;
+    }
+
+    public function getValueListsTwoFields($Vd33e904c = null)
+    {
+        $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return $this->Vab234ad8;
+    }
+    public function getValueLists($Vd33e904c = null)
+    {
+        $Vb4a88417 = $this->loadExtendedInfo($Vd33e904c);
+        if (FileMaker::isError($Vb4a88417)) {
+            return $Vb4a88417;
+        }
+        return $this->_valueLists;
+    }
+    public function loadExtendedInfo($Vd33e904c = null)
+    {
+        if (!$this->_extended) {
+
+            if ($Vd33e904c != null) {
+                $V0f635d0e = $this->_fm->_execute(array('-db' => $this->_fm->getProperty('database'),
+                    '-lay' => $this->getName(),
+                    '-recid' => $Vd33e904c,
+                    '-view' => null),
+                    'FMPXMLLAYOUT');
+            } else {
+                $V0f635d0e = $this->_fm->_execute(array('-db' => $this->_fm->getProperty('database'),
+                    '-lay' => $this->getName(),
+                    '-view' => null),
+                    'FMPXMLLAYOUT');
+
+            }
+            $V3643b863 = new FileMaker_Parser_FMPXMLLAYOUT($this->_fm);
+            $Vb4a88417 = $V3643b863->parse($V0f635d0e);
+            if (FileMaker::isError($Vb4a88417)) {
+                return $Vb4a88417;
+            }
+            $V3643b863->setExtendedInfo($this);
+            $this->_extended = true;
+        }
+        return $this->_extended;
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Parser/FMPXMLLAYOUT.php
+++ b/src/FMAPI/FileMaker/Implementation/Parser/FMPXMLLAYOUT.php
@@ -1,118 +1,117 @@
 <?php
-  class FileMaker_Parser_FMPXMLLAYOUT
+class FileMaker_Parser_FMPXMLLAYOUT
 {
-  var $Vd05b6ed7;
- var $Ve3ad9440;
+    public $Vd05b6ed7;
+    public $Ve3ad9440;
 
-  
- var $V6a45a325;
- var $_fm;
- var $V5431b8d4;
- var $V6de51026 = false;
- var $V191be3bd;
- var $V32e51cce;
+    public $V6a45a325;
+    public $_fm;
+    public $V5431b8d4;
+    public $V6de51026 = false;
+    public $V191be3bd;
+    public $V32e51cce;
 
-  
- var$V582ddd29;
- function FileMaker_Parser_FMPXMLLAYOUT(&$V0ab34ca9)
- {
- $this->_fm =& $V0ab34ca9;
-}
- function parse($V0f635d0e)
- {
- if (empty($V0f635d0e)) {
- return new FileMaker_Error($this->_fm, 'Did not receive an XML document from the server.');
-} 
- $this->V5431b8d4= xml_parser_create();
-xml_set_object($this->V5431b8d4, $this);
-xml_parser_set_option($this->V5431b8d4, XML_OPTION_CASE_FOLDING, false);
-xml_parser_set_option($this->V5431b8d4, XML_OPTION_TARGET_ENCODING, 'UTF-8');
-xml_set_element_handler($this->V5431b8d4, '_start', '_end');
-xml_set_character_data_handler($this->V5431b8d4, '_cdata'); 
- if (!@xml_parse($this->V5431b8d4, $V0f635d0e)) {
- return new FileMaker_Error(sprintf('XML error: %s at line %d',
- xml_error_string(xml_get_error_code($this->V5431b8d4)),
- xml_get_current_line_number($this->V5431b8d4)));
-} 
- xml_parser_free($this->V5431b8d4); 
- if (!empty($this->Vcb5e100e)) {
- return new FileMaker_Error($this->_fm, null, $this->Vcb5e100e);
-}
-$this->V6de51026= true;
-return true;
-}
- function setExtendedInfo(&$Vc6140495)
- {
- if (!$this->V6de51026) {
- return new FileMaker_Error($this->_fm, 'Attempt to set extended information before parsing data.');
-}
-$Vc6140495->_valueLists = $this->Ve3ad9440;
-$Vc6140495->Vab234ad8= $this->V6a45a325;
-foreach ($this->Vd05b6ed7 as $V972bf3f0 => $V77be71a4) {
- $V8fa14cdd =& $Vc6140495->getField($V972bf3f0);
-$V8fa14cdd->_impl->_styleType = $V77be71a4['styleType'];
-$V8fa14cdd->_impl->_valueList = $V77be71a4['valueList'] ? $V77be71a4['valueList'] : null;
-}
-}
- function _start($V3643b863, $Vb068931c, $V5d06e8a3)
- { 
- $V5d06e8a3 = $this->_fm->toOutputCharset($V5d06e8a3);
-switch ($Vb068931c) {
- case 'FIELD':
- $this->V191be3bd= $V5d06e8a3['NAME'];
-break;
-case 'STYLE':
- $this->Vd05b6ed7[$this->V191be3bd]['styleType'] = $V5d06e8a3['TYPE'];
-$this->Vd05b6ed7[$this->V191be3bd]['valueList'] = $V5d06e8a3['VALUELIST'];
-break;
-case 'VALUELIST':
- $this->Ve3ad9440[$V5d06e8a3['NAME']] = array();
-$this->V6a45a325[$V5d06e8a3['NAME']] = array();
-$this->V32e51cce= $V5d06e8a3['NAME'];
-break;
-case 'VALUE':
- $this->V582ddd29= $V5d06e8a3['DISPLAY'];
-$this->Ve3ad9440[$this->V32e51cce][] = '';
-break;
-}
-$this->inside_data = false;
-}
- function _end($V3643b863, $Vb068931c)
- {
- switch ($Vb068931c) {
- case 'FIELD':
- $this->V191be3bd= null;
-break;
-case 'VALUELIST':
- $this->V32e51cce= null;
-break;
-}
+    public $V582ddd29;
+    public function __construct(&$V0ab34ca9)
+    {
+        $this->_fm = &$V0ab34ca9;
+    }
+    public function parse($V0f635d0e)
+    {
+        if (empty($V0f635d0e)) {
+            return new FileMaker_Error($this->_fm, 'Did not receive an XML document from the server.');
+        }
+        $this->V5431b8d4 = xml_parser_create();
+        xml_set_object($this->V5431b8d4, $this);
+        xml_parser_set_option($this->V5431b8d4, XML_OPTION_CASE_FOLDING, false);
+        xml_parser_set_option($this->V5431b8d4, XML_OPTION_TARGET_ENCODING, 'UTF-8');
+        xml_set_element_handler($this->V5431b8d4, '_start', '_end');
+        xml_set_character_data_handler($this->V5431b8d4, '_cdata');
+        if (!@xml_parse($this->V5431b8d4, $V0f635d0e)) {
+            return new FileMaker_Error(sprintf('XML error: %s at line %d',
+                xml_error_string(xml_get_error_code($this->V5431b8d4)),
+                xml_get_current_line_number($this->V5431b8d4)));
+        }
+        xml_parser_free($this->V5431b8d4);
+        if (!empty($this->Vcb5e100e)) {
+            return new FileMaker_Error($this->_fm, null, $this->Vcb5e100e);
+        }
+        $this->V6de51026 = true;
+        return true;
+    }
+    public function setExtendedInfo(&$Vc6140495)
+    {
+        if (!$this->V6de51026) {
+            return new FileMaker_Error($this->_fm, 'Attempt to set extended information before parsing data.');
+        }
+        $Vc6140495->_valueLists = $this->Ve3ad9440;
+        $Vc6140495->Vab234ad8 = $this->V6a45a325;
+        foreach ($this->Vd05b6ed7 as $V972bf3f0 => $V77be71a4) {
+            $V8fa14cdd = &$Vc6140495->getField($V972bf3f0);
+            $V8fa14cdd->_impl->_styleType = $V77be71a4['styleType'];
+            $V8fa14cdd->_impl->_valueList = $V77be71a4['valueList'] ? $V77be71a4['valueList'] : null;
+        }
+    }
+    public function _start($V3643b863, $Vb068931c, $V5d06e8a3)
+    {
+        $V5d06e8a3 = $this->_fm->toOutputCharset($V5d06e8a3);
+        switch ($Vb068931c) {
+            case 'FIELD':
+                $this->V191be3bd = $V5d06e8a3['NAME'];
+                break;
+            case 'STYLE':
+                $this->Vd05b6ed7[$this->V191be3bd]['styleType'] = $V5d06e8a3['TYPE'];
+                $this->Vd05b6ed7[$this->V191be3bd]['valueList'] = $V5d06e8a3['VALUELIST'];
+                break;
+            case 'VALUELIST':
+                $this->Ve3ad9440[$V5d06e8a3['NAME']] = array();
+                $this->V6a45a325[$V5d06e8a3['NAME']] = array();
+                $this->V32e51cce = $V5d06e8a3['NAME'];
+                break;
+            case 'VALUE':
+                $this->V582ddd29 = $V5d06e8a3['DISPLAY'];
+                $this->Ve3ad9440[$this->V32e51cce][] = '';
+                break;
+        }
+        $this->inside_data = false;
+    }
+    public function _end($V3643b863, $Vb068931c)
+    {
+        switch ($Vb068931c) {
+            case 'FIELD':
+                $this->V191be3bd = null;
+                break;
+            case 'VALUELIST':
+                $this->V32e51cce = null;
+                break;
+        }
 
- $this->inside_data = false;
-}
- function _cdata($V3643b863, $V8d777f38)
- {
- if ($this->V32e51cce!== null && preg_match('|\S|', $V8d777f38)) {  
- if($this->inside_data){
- $V78656626 = $this->V6a45a325[$this->V32e51cce][$this->V582ddd29];
-$V8d777f38 = $V78656626 . $V8d777f38;
-}
-$V83ee0926 = array( $this->V582ddd29=> $this->_fm->toOutputCharset($V8d777f38));
-$this->associative_array_push($this->V6a45a325[$this->V32e51cce], $V83ee0926);
-$this->Ve3ad9440[$this->V32e51cce][count($this->Ve3ad9440[$this->V32e51cce]) - 1] .= $this->_fm->toOutputCharset($V8d777f38);
-$this->inside_data = true;
-}
+        $this->inside_data = false;
+    }
+    public function _cdata($V3643b863, $V8d777f38)
+    {
+        if ($this->V32e51cce !== null && preg_match('|\S|', $V8d777f38)) {
 
- }
+            if ($this->inside_data) {
+                $V78656626 = $this->V6a45a325[$this->V32e51cce][$this->V582ddd29];
+                $V8d777f38 = $V78656626 . $V8d777f38;
+            }
+            $V83ee0926 = array($this->V582ddd29 => $this->_fm->toOutputCharset($V8d777f38));
+            $this->associative_array_push($this->V6a45a325[$this->V32e51cce], $V83ee0926);
+            $this->Ve3ad9440[$this->V32e51cce][count($this->Ve3ad9440[$this->V32e51cce]) - 1] .= $this->_fm->toOutputCharset($V8d777f38);
+            $this->inside_data = true;
+        }
 
-	 
-	function associative_array_push(&$Vf1f713c9, $V34ec78fc) {
- if (is_array($V34ec78fc)) {
- foreach ($V34ec78fc as $V3c6e0b8a => $V2063c160) {
- $Vf1f713c9[$V3c6e0b8a] = $V2063c160;
-}
-return $Vf1f713c9;
-}
-return false;
-}
+    }
+
+    public function associative_array_push(&$Vf1f713c9, $V34ec78fc)
+    {
+        if (is_array($V34ec78fc)) {
+            foreach ($V34ec78fc as $V3c6e0b8a => $V2063c160) {
+                $Vf1f713c9[$V3c6e0b8a] = $V2063c160;
+            }
+            return $Vf1f713c9;
+        }
+        return false;
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/Parser/FMResultSet.php
+++ b/src/FMAPI/FileMaker/Implementation/Parser/FMResultSet.php
@@ -1,281 +1,281 @@
 <?php
-  require_once dirname(__FILE__) . '/../../Layout.php';
+require_once dirname(__FILE__) . '/../../Layout.php';
 require_once dirname(__FILE__) . '/../../RelatedSet.php';
 require_once dirname(__FILE__) . '/../../Record.php';
 require_once dirname(__FILE__) . '/../../Field.php';
- class FileMaker_Parser_FMResultSet
+class FileMaker_Parser_FMResultSet
 {
-  var $Vcb5e100e;
- var $Vf5bf48aa;
- var $V1ea7e575;
- var $V9f81f3c0 = array();
- var $Vaae0d98d;
- var $Vae581270 = array();
- var $V6e52c40b = array();
- var $Ve13f1c92;
- var $V43432a31;
- var $V51bc3e3b;
- var $V26005321;
- var $V6468d939;
- var $_fm;
- var $V5431b8d4;
- var $V6de51026 = false;
- var $_result;
- var $_layout;
- function FileMaker_Parser_FMResultSet(&$V0ab34ca9)
- {
- $this->_fm =& $V0ab34ca9;
-}
- function parse($V0f635d0e)
- {
- if (empty($V0f635d0e)) {
- return new FileMaker_Error($this->_fm, 'Did not receive an XML document from the server.');
-} 
- $this->V5431b8d4= xml_parser_create('UTF-8');
-xml_set_object($this->V5431b8d4, $this);
-xml_parser_set_option($this->V5431b8d4, XML_OPTION_CASE_FOLDING, false);
-xml_parser_set_option($this->V5431b8d4, XML_OPTION_TARGET_ENCODING, 'UTF-8');
-xml_set_element_handler($this->V5431b8d4, '_start', '_end');
-xml_set_character_data_handler($this->V5431b8d4, '_cdata'); 
- if (!@xml_parse($this->V5431b8d4, $V0f635d0e)) {
- return new FileMaker_Error($this->_fm,
- sprintf('XML error: %s at line %d',
- xml_error_string(xml_get_error_code($this->V5431b8d4)),
- xml_get_current_line_number($this->V5431b8d4)));
-} 
- xml_parser_free($this->V5431b8d4); 
- if (!empty($this->Vcb5e100e)) {
- return new FileMaker_Error($this->_fm, null, $this->Vcb5e100e);
-}  
- if (version_compare($this->Vf5bf48aa['version'], FileMaker::getMinServerVersion(), '<')) {
- return new FileMaker_Error($this->_fm, 'This API requires at least version ' . FileMaker::getMinServerVersion() . ' of FileMaker Server to run (detected ' . $this->Vf5bf48aa['version'] . ').');
-}
-$this->V6de51026= true;
-return true;
-}
- function setResult(&$Vb4a88417, $V561b2299 = 'FileMaker_Record')
- {
- if (!$this->V6de51026) {
- return new FileMaker_Error($this->_fm, 'Attempt to get a result object before parsing data.');
-}
-if ($this->_result) {
- $Vb4a88417 =& $this->_result;
-return true;
-} 
- $Vb4a88417->_impl->_layout = new FileMaker_Layout($this->_fm);
-$this->setLayout($Vb4a88417->_impl->_layout); 
- $Vb4a88417->_impl->_tableCount = $this->V1ea7e575['total-count'];
-$Vb4a88417->_impl->_foundSetCount = $this->Vaae0d98d['count'];
-$Vb4a88417->_impl->_fetchCount = $this->Vaae0d98d['fetch-size']; 
- $V6e52c40b = array();
-foreach ($this->V6e52c40b as $Vde17f0f2) {
- $V4b43b0ae = new $V561b2299($Vb4a88417->_impl->_layout);
-$V4b43b0ae->_impl->_fields = $Vde17f0f2['fields'];
-$V4b43b0ae->_impl->_recordId = $Vde17f0f2['record-id'];
-$V4b43b0ae->_impl->_modificationId = $Vde17f0f2['mod-id'];
-if ($Vde17f0f2['children']) {
- foreach ($Vde17f0f2['children'] as $Vaca007a7 => $V268184c1) {
- $V4b43b0ae->_impl->_relatedSets[$Vaca007a7] = array();
-foreach ($V268184c1 as $V1b7d5726) {
- $V4a8a08f0 = new $V561b2299($Vb4a88417->_impl->_layout->getRelatedSet($Vaca007a7));
-$V4a8a08f0->_impl->_fields = $V1b7d5726['fields'];
-$V4a8a08f0->_impl->_recordId = $V1b7d5726['record-id'];
-$V4a8a08f0->_impl->_modificationId = $V1b7d5726['mod-id'];
-$V4a8a08f0->_impl->_parent = $V4b43b0ae;
-$V4b43b0ae->_impl->_relatedSets[$Vaca007a7][] = $V4a8a08f0;
-}
-}
-}
-$V6e52c40b[] = $V4b43b0ae;
-}
-$Vb4a88417->_impl->_records =& $V6e52c40b;
-$this->_result =& $Vb4a88417;
-true;
-}
- function setLayout(&$Vc6140495)
- {
- if (!$this->V6de51026) {
- return new FileMaker_Error($this->_fm, 'Attempt to get a layout object before parsing data.');
-}
-if ($this->_layout) {
- $Vc6140495 =& $this->_layout;
-return true;
-}
-$Vc6140495->_impl->_name = $this->V1ea7e575['layout'];
-$Vc6140495->_impl->_database = $this->V1ea7e575['database'];
-foreach ($this->V9f81f3c0 as $V06e3d36f) {
- $V8fa14cdd = new FileMaker_Field($Vc6140495);
-$V8fa14cdd->_impl->_name = $V06e3d36f['name'];
-$V8fa14cdd->_impl->_autoEntered = (bool)($V06e3d36f['auto-enter'] == 'yes');
-$V8fa14cdd->_impl->_global = (bool)($V06e3d36f['global'] == 'yes');
-$V8fa14cdd->_impl->_maxRepeat = (int)$V06e3d36f['max-repeat'];
-$V8fa14cdd->_impl->_result = $V06e3d36f['result'];
-$V8fa14cdd->_impl->_type = $V06e3d36f['type']; 
- if ($V06e3d36f['not-empty'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NOTEMPTY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NOTEMPTY;
-}
-if ($V06e3d36f['numeric-only'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NUMERICONLY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NUMERICONLY;
-}
-if (array_key_exists('max-characters', $V06e3d36f)) {
- $V8fa14cdd->_impl->_maxCharacters = (int) $V06e3d36f['max-characters'];
-$V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_MAXCHARACTERS] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_MAXCHARACTERS;
-}
-if ($V06e3d36f['four-digit-year'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_FOURDIGITYEAR] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_FOURDIGITYEAR;
-}
-if ($V06e3d36f['time-of-day'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMEOFDAY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMEOFDAY;
-}
-if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'timestamp') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMESTAMP_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMESTAMP_FIELD;
-}
-if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'date') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_DATE_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_DATE_FIELD;
-}
-if ($V06e3d36f['time-of-day'] == 'no' && $V06e3d36f['result'] == 'time') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIME_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIME_FIELD;
-}
-$Vc6140495->_impl->_fields[$V8fa14cdd->getName()] = $V8fa14cdd;
-}
-foreach ($this->Vae581270 as $Vaca007a7 => $V53256610) {
- $V4b43b0ae = new FileMaker_RelatedSet($Vc6140495);
-$V4b43b0ae->_impl->_name = $Vaca007a7;
-foreach ($V53256610 as $V06e3d36f) {
- $V8fa14cdd = new FileMaker_Field($V4b43b0ae);
-$V8fa14cdd->_impl->_name = $V06e3d36f['name'];
-$V8fa14cdd->_impl->_autoEntered = (bool)($V06e3d36f['auto-enter'] == 'yes');
-$V8fa14cdd->_impl->_global = (bool)($V06e3d36f['global'] == 'yes');
-$V8fa14cdd->_impl->_maxRepeat = (int)$V06e3d36f['max-repeat'];
-$V8fa14cdd->_impl->_result = $V06e3d36f['result'];
-$V8fa14cdd->_impl->_type = $V06e3d36f['type']; 
- if ($V06e3d36f['not-empty'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NOTEMPTY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NOTEMPTY;
-}
-if ($V06e3d36f['numeric-only'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NUMERICONLY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NUMERICONLY;
-}
-if (array_key_exists('max-characters', $V06e3d36f)) {
- $V8fa14cdd->_impl->_maxCharacters = (int) $V06e3d36f['max-characters'];
-$V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_MAXCHARACTERS] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_MAXCHARACTERS;
-}
-if ($V06e3d36f['four-digit-year'] == 'yes') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_FOURDIGITYEAR] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_FOURDIGITYEAR;
-}
-if ($V06e3d36f['time-of-day'] == 'yes' || $V06e3d36f['result'] == 'time') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMEOFDAY] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMEOFDAY;
-}
-if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'timestamp') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMESTAMP_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMESTAMP_FIELD;
-}
-if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'date') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_DATE_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_DATE_FIELD;
-}
-if ($V06e3d36f['time-of-day'] == 'no' && $V06e3d36f['result'] == 'time') {
- $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIME_FIELD] = true;
-$V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIME_FIELD;
-}
-$V4b43b0ae->_impl->_fields[$V8fa14cdd->getName()] = $V8fa14cdd;
-}
-$Vc6140495->_impl->_relatedSets[$V4b43b0ae->getName()] = $V4b43b0ae;
-}
-$this->_layout =& $Vc6140495;
-return true;
-}
- function _start($V3643b863, $Vb068931c, $V5d06e8a3)
- { 
- $V5d06e8a3 = $this->_fm->toOutputCharset($V5d06e8a3);
-switch ($Vb068931c) {
- case 'error':
- $this->Vcb5e100e= $V5d06e8a3['code'];
-break;
-case 'product':
- $this->Vf5bf48aa= $V5d06e8a3;
-break;
-case 'datasource':
- $this->V1ea7e575= $V5d06e8a3;
-break;
-case 'relatedset-definition':
- $this->Vae581270[$V5d06e8a3['table']] = array();
-$this->Ve13f1c92= $V5d06e8a3['table'];
-break;
-case 'field-definition':
- if ($this->Ve13f1c92) {
- $this->Vae581270[$this->Ve13f1c92][] = $V5d06e8a3;
-} else {
- $this->V9f81f3c0[] = $V5d06e8a3;
-}
-break;
-case 'resultset':
- $this->Vaae0d98d= $V5d06e8a3;
-break;
-case 'relatedset':
- $this->Ve13f1c92= $V5d06e8a3['table'];
-$this->V51bc3e3b= $this->V43432a31;
-$this->V51bc3e3b['children'][$this->Ve13f1c92] = array();
-$this->V43432a31= null;
-break;
-case 'record':
- $this->V43432a31=
- array('record-id' => $V5d06e8a3['record-id'],
- 'mod-id' => $V5d06e8a3['mod-id'],
- 'fields' => array(),
- 'children' => array());
-break;
-case 'field':
- $this->V26005321= $V5d06e8a3['name'];
-$this->V43432a31['fields'][$this->V26005321] = array();
-break;
-case 'data':
- $this->V6468d939= '';
-break;
-}
-}
- function _end($V3643b863, $Vb068931c)
- {
- switch ($Vb068931c) {
- case 'relatedset-definition':
- $this->Ve13f1c92= null;
-break;
-case 'relatedset':
- $this->Ve13f1c92= null;
-$this->V43432a31= $this->V51bc3e3b;
-$this->V51bc3e3b= null;
-break;
-case 'record':
- if ($this->Ve13f1c92) {
- $this->V51bc3e3b['children'][$this->Ve13f1c92][] = $this->V43432a31;
-} else {
- $this->V6e52c40b[] = $this->V43432a31;
-}
-$this->V43432a31= null;
-break;
-case 'field':
- $this->V26005321= null;
-break;
-case 'data':
- $this->V43432a31['fields'][$this->V26005321][] = $this->V6468d939;
-$this->V6468d939= null;
-break;
-}
-}
- function _cdata($V3643b863, $V8d777f38)
- {
- $this->V6468d939.= $this->_fm->toOutputCharset($V8d777f38);
-}
+    public $Vcb5e100e;
+    public $Vf5bf48aa;
+    public $V1ea7e575;
+    public $V9f81f3c0 = array();
+    public $Vaae0d98d;
+    public $Vae581270 = array();
+    public $V6e52c40b = array();
+    public $Ve13f1c92;
+    public $V43432a31;
+    public $V51bc3e3b;
+    public $V26005321;
+    public $V6468d939;
+    public $_fm;
+    public $V5431b8d4;
+    public $V6de51026 = false;
+    public $_result;
+    public $_layout;
+    public function __construct(&$V0ab34ca9)
+    {
+        $this->_fm = &$V0ab34ca9;
+    }
+    public function parse($V0f635d0e)
+    {
+        if (empty($V0f635d0e)) {
+            return new FileMaker_Error($this->_fm, 'Did not receive an XML document from the server.');
+        }
+        $this->V5431b8d4 = xml_parser_create('UTF-8');
+        xml_set_object($this->V5431b8d4, $this);
+        xml_parser_set_option($this->V5431b8d4, XML_OPTION_CASE_FOLDING, false);
+        xml_parser_set_option($this->V5431b8d4, XML_OPTION_TARGET_ENCODING, 'UTF-8');
+        xml_set_element_handler($this->V5431b8d4, '_start', '_end');
+        xml_set_character_data_handler($this->V5431b8d4, '_cdata');
+        if (!@xml_parse($this->V5431b8d4, $V0f635d0e)) {
+            return new FileMaker_Error($this->_fm,
+                sprintf('XML error: %s at line %d',
+                    xml_error_string(xml_get_error_code($this->V5431b8d4)),
+                    xml_get_current_line_number($this->V5431b8d4)));
+        }
+        xml_parser_free($this->V5431b8d4);
+        if (!empty($this->Vcb5e100e)) {
+            return new FileMaker_Error($this->_fm, null, $this->Vcb5e100e);
+        }
+        if (version_compare($this->Vf5bf48aa['version'], FileMaker::getMinServerVersion(), '<')) {
+            return new FileMaker_Error($this->_fm, 'This API requires at least version ' . FileMaker::getMinServerVersion() . ' of FileMaker Server to run (detected ' . $this->Vf5bf48aa['version'] . ').');
+        }
+        $this->V6de51026 = true;
+        return true;
+    }
+    public function setResult(&$Vb4a88417, $V561b2299 = 'FileMaker_Record')
+    {
+        if (!$this->V6de51026) {
+            return new FileMaker_Error($this->_fm, 'Attempt to get a result object before parsing data.');
+        }
+        if ($this->_result) {
+            $Vb4a88417 = &$this->_result;
+            return true;
+        }
+        $Vb4a88417->_impl->_layout = new FileMaker_Layout($this->_fm);
+        $this->setLayout($Vb4a88417->_impl->_layout);
+        $Vb4a88417->_impl->_tableCount = $this->V1ea7e575['total-count'];
+        $Vb4a88417->_impl->_foundSetCount = $this->Vaae0d98d['count'];
+        $Vb4a88417->_impl->_fetchCount = $this->Vaae0d98d['fetch-size'];
+        $V6e52c40b = array();
+        foreach ($this->V6e52c40b as $Vde17f0f2) {
+            $V4b43b0ae = new $V561b2299($Vb4a88417->_impl->_layout);
+            $V4b43b0ae->_impl->_fields = $Vde17f0f2['fields'];
+            $V4b43b0ae->_impl->_recordId = $Vde17f0f2['record-id'];
+            $V4b43b0ae->_impl->_modificationId = $Vde17f0f2['mod-id'];
+            if ($Vde17f0f2['children']) {
+                foreach ($Vde17f0f2['children'] as $Vaca007a7 => $V268184c1) {
+                    $V4b43b0ae->_impl->_relatedSets[$Vaca007a7] = array();
+                    foreach ($V268184c1 as $V1b7d5726) {
+                        $V4a8a08f0 = new $V561b2299($Vb4a88417->_impl->_layout->getRelatedSet($Vaca007a7));
+                        $V4a8a08f0->_impl->_fields = $V1b7d5726['fields'];
+                        $V4a8a08f0->_impl->_recordId = $V1b7d5726['record-id'];
+                        $V4a8a08f0->_impl->_modificationId = $V1b7d5726['mod-id'];
+                        $V4a8a08f0->_impl->_parent = $V4b43b0ae;
+                        $V4b43b0ae->_impl->_relatedSets[$Vaca007a7][] = $V4a8a08f0;
+                    }
+                }
+            }
+            $V6e52c40b[] = $V4b43b0ae;
+        }
+        $Vb4a88417->_impl->_records = &$V6e52c40b;
+        $this->_result = &$Vb4a88417;
+        true;
+    }
+    public function setLayout(&$Vc6140495)
+    {
+        if (!$this->V6de51026) {
+            return new FileMaker_Error($this->_fm, 'Attempt to get a layout object before parsing data.');
+        }
+        if ($this->_layout) {
+            $Vc6140495 = &$this->_layout;
+            return true;
+        }
+        $Vc6140495->_impl->_name = $this->V1ea7e575['layout'];
+        $Vc6140495->_impl->_database = $this->V1ea7e575['database'];
+        foreach ($this->V9f81f3c0 as $V06e3d36f) {
+            $V8fa14cdd = new FileMaker_Field($Vc6140495);
+            $V8fa14cdd->_impl->_name = $V06e3d36f['name'];
+            $V8fa14cdd->_impl->_autoEntered = (bool) ($V06e3d36f['auto-enter'] == 'yes');
+            $V8fa14cdd->_impl->_global = (bool) ($V06e3d36f['global'] == 'yes');
+            $V8fa14cdd->_impl->_maxRepeat = (int) $V06e3d36f['max-repeat'];
+            $V8fa14cdd->_impl->_result = $V06e3d36f['result'];
+            $V8fa14cdd->_impl->_type = $V06e3d36f['type'];
+            if ($V06e3d36f['not-empty'] == 'yes') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NOTEMPTY] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NOTEMPTY;
+            }
+            if ($V06e3d36f['numeric-only'] == 'yes') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NUMERICONLY] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NUMERICONLY;
+            }
+            if (array_key_exists('max-characters', $V06e3d36f)) {
+                $V8fa14cdd->_impl->_maxCharacters = (int) $V06e3d36f['max-characters'];
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_MAXCHARACTERS] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_MAXCHARACTERS;
+            }
+            if ($V06e3d36f['four-digit-year'] == 'yes') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_FOURDIGITYEAR] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_FOURDIGITYEAR;
+            }
+            if ($V06e3d36f['time-of-day'] == 'yes') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMEOFDAY] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMEOFDAY;
+            }
+            if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'timestamp') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMESTAMP_FIELD] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMESTAMP_FIELD;
+            }
+            if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'date') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_DATE_FIELD] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_DATE_FIELD;
+            }
+            if ($V06e3d36f['time-of-day'] == 'no' && $V06e3d36f['result'] == 'time') {
+                $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIME_FIELD] = true;
+                $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIME_FIELD;
+            }
+            $Vc6140495->_impl->_fields[$V8fa14cdd->getName()] = $V8fa14cdd;
+        }
+        foreach ($this->Vae581270 as $Vaca007a7 => $V53256610) {
+            $V4b43b0ae = new FileMaker_RelatedSet($Vc6140495);
+            $V4b43b0ae->_impl->_name = $Vaca007a7;
+            foreach ($V53256610 as $V06e3d36f) {
+                $V8fa14cdd = new FileMaker_Field($V4b43b0ae);
+                $V8fa14cdd->_impl->_name = $V06e3d36f['name'];
+                $V8fa14cdd->_impl->_autoEntered = (bool) ($V06e3d36f['auto-enter'] == 'yes');
+                $V8fa14cdd->_impl->_global = (bool) ($V06e3d36f['global'] == 'yes');
+                $V8fa14cdd->_impl->_maxRepeat = (int) $V06e3d36f['max-repeat'];
+                $V8fa14cdd->_impl->_result = $V06e3d36f['result'];
+                $V8fa14cdd->_impl->_type = $V06e3d36f['type'];
+                if ($V06e3d36f['not-empty'] == 'yes') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NOTEMPTY] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NOTEMPTY;
+                }
+                if ($V06e3d36f['numeric-only'] == 'yes') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_NUMERICONLY] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_NUMERICONLY;
+                }
+                if (array_key_exists('max-characters', $V06e3d36f)) {
+                    $V8fa14cdd->_impl->_maxCharacters = (int) $V06e3d36f['max-characters'];
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_MAXCHARACTERS] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_MAXCHARACTERS;
+                }
+                if ($V06e3d36f['four-digit-year'] == 'yes') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_FOURDIGITYEAR] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_FOURDIGITYEAR;
+                }
+                if ($V06e3d36f['time-of-day'] == 'yes' || $V06e3d36f['result'] == 'time') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMEOFDAY] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMEOFDAY;
+                }
+                if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'timestamp') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIMESTAMP_FIELD] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIMESTAMP_FIELD;
+                }
+                if ($V06e3d36f['four-digit-year'] == 'no' && $V06e3d36f['result'] == 'date') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_DATE_FIELD] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_DATE_FIELD;
+                }
+                if ($V06e3d36f['time-of-day'] == 'no' && $V06e3d36f['result'] == 'time') {
+                    $V8fa14cdd->_impl->_validationRules[FILEMAKER_RULE_TIME_FIELD] = true;
+                    $V8fa14cdd->_impl->_validationMask |= FILEMAKER_RULE_TIME_FIELD;
+                }
+                $V4b43b0ae->_impl->_fields[$V8fa14cdd->getName()] = $V8fa14cdd;
+            }
+            $Vc6140495->_impl->_relatedSets[$V4b43b0ae->getName()] = $V4b43b0ae;
+        }
+        $this->_layout = &$Vc6140495;
+        return true;
+    }
+    public function _start($V3643b863, $Vb068931c, $V5d06e8a3)
+    {
+        $V5d06e8a3 = $this->_fm->toOutputCharset($V5d06e8a3);
+        switch ($Vb068931c) {
+            case 'error':
+                $this->Vcb5e100e = $V5d06e8a3['code'];
+                break;
+            case 'product':
+                $this->Vf5bf48aa = $V5d06e8a3;
+                break;
+            case 'datasource':
+                $this->V1ea7e575 = $V5d06e8a3;
+                break;
+            case 'relatedset-definition':
+                $this->Vae581270[$V5d06e8a3['table']] = array();
+                $this->Ve13f1c92 = $V5d06e8a3['table'];
+                break;
+            case 'field-definition':
+                if ($this->Ve13f1c92) {
+                    $this->Vae581270[$this->Ve13f1c92][] = $V5d06e8a3;
+                } else {
+                    $this->V9f81f3c0[] = $V5d06e8a3;
+                }
+                break;
+            case 'resultset':
+                $this->Vaae0d98d = $V5d06e8a3;
+                break;
+            case 'relatedset':
+                $this->Ve13f1c92 = $V5d06e8a3['table'];
+                $this->V51bc3e3b = $this->V43432a31;
+                $this->V51bc3e3b['children'][$this->Ve13f1c92] = array();
+                $this->V43432a31 = null;
+                break;
+            case 'record':
+                $this->V43432a31 =
+                array('record-id' => $V5d06e8a3['record-id'],
+                    'mod-id' => $V5d06e8a3['mod-id'],
+                    'fields' => array(),
+                    'children' => array());
+                break;
+            case 'field':
+                $this->V26005321 = $V5d06e8a3['name'];
+                $this->V43432a31['fields'][$this->V26005321] = array();
+                break;
+            case 'data':
+                $this->V6468d939 = '';
+                break;
+        }
+    }
+    public function _end($V3643b863, $Vb068931c)
+    {
+        switch ($Vb068931c) {
+            case 'relatedset-definition':
+                $this->Ve13f1c92 = null;
+                break;
+            case 'relatedset':
+                $this->Ve13f1c92 = null;
+                $this->V43432a31 = $this->V51bc3e3b;
+                $this->V51bc3e3b = null;
+                break;
+            case 'record':
+                if ($this->Ve13f1c92) {
+                    $this->V51bc3e3b['children'][$this->Ve13f1c92][] = $this->V43432a31;
+                } else {
+                    $this->V6e52c40b[] = $this->V43432a31;
+                }
+                $this->V43432a31 = null;
+                break;
+            case 'field':
+                $this->V26005321 = null;
+                break;
+            case 'data':
+                $this->V43432a31['fields'][$this->V26005321][] = $this->V6468d939;
+                $this->V6468d939 = null;
+                break;
+        }
+    }
+    public function _cdata($V3643b863, $V8d777f38)
+    {
+        $this->V6468d939 .= $this->_fm->toOutputCharset($V8d777f38);
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/RecordImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/RecordImpl.php
@@ -1,302 +1,301 @@
 <?php
-  class FileMaker_Record_Implementation
+class FileMaker_Record_Implementation
 {
-  var $_fields = array();
- var $V5e7ec2d5 = array();
- var $_recordId;
- var $_modificationId;
- var $_layout;
- var $_fm;
- var $_relatedSets = array();
- var $_parent = null;
- function FileMaker_Record_Implementation(&$Vc6140495)
- {
- $this->_layout =& $Vc6140495;
-$this->_fm =& $Vc6140495->_impl->_fm;
-}
- function &getLayout()
- {
- return $this->_layout;
-}
- function getFields()
- {
- return $this->_layout->listFields();
-}
- function getField($V06e3d36f, $V6d786dc7 = 0)
- {
- if (!isset($this->_fields[$V06e3d36f])) {
- $this->_fm->log('Field "' . $V06e3d36f . '" not found.', FILEMAKER_LOG_INFO);
-return "";
-}
-if (!isset($this->_fields[$V06e3d36f][$V6d786dc7])) {
- $this->_fm->log('Repetition "' . (int)$V6d786dc7 . '" does not exist for "' . $V06e3d36f . '".', FILEMAKER_LOG_INFO);
-return "";
-}
-return htmlspecialchars($this->_fields[$V06e3d36f][$V6d786dc7]);
-}
+    public $_fields = array();
+    public $V5e7ec2d5 = array();
+    public $_recordId;
+    public $_modificationId;
+    public $_layout;
+    public $_fm;
+    public $_relatedSets = array();
+    public $_parent = null;
+    public function __construct(&$Vc6140495)
+    {
+        $this->_layout = &$Vc6140495;
+        $this->_fm = &$Vc6140495->_impl->_fm;
+    }
+    public function &getLayout()
+    {
+        return $this->_layout;
+    }
+    public function getFields()
+    {
+        return $this->_layout->listFields();
+    }
+    public function getField($V06e3d36f, $V6d786dc7 = 0)
+    {
+        if (!isset($this->_fields[$V06e3d36f])) {
+            $this->_fm->log('Field "' . $V06e3d36f . '" not found.', FILEMAKER_LOG_INFO);
+            return "";
+        }
+        if (!isset($this->_fields[$V06e3d36f][$V6d786dc7])) {
+            $this->_fm->log('Repetition "' . (int) $V6d786dc7 . '" does not exist for "' . $V06e3d36f . '".', FILEMAKER_LOG_INFO);
+            return "";
+        }
+        return htmlspecialchars($this->_fields[$V06e3d36f][$V6d786dc7]);
+    }
 
-	 function getFieldUnencoded($V06e3d36f, $V6d786dc7 = 0)
- {
- if (!isset($this->_fields[$V06e3d36f])) {
- $this->_fm->log('Field "' . $V06e3d36f . '" not found.', FILEMAKER_LOG_INFO);
-return "";
-}
-if (!isset($this->_fields[$V06e3d36f][$V6d786dc7])) {
- $this->_fm->log('Repetition "' . (int)$V6d786dc7 . '" does not exist for "' . $V06e3d36f . '".', FILEMAKER_LOG_INFO);
-return "";
-}
-return $this->_fields[$V06e3d36f][$V6d786dc7];
-}
- function getFieldAsTimestamp($V972bf3f0, $V6d786dc7 = 0)
- {
- $V2063c160 = $this->getField($V972bf3f0, $V6d786dc7);
-if (FileMaker::isError($V2063c160)) {
- return $V2063c160;
-}
-$V06e3d36f =& $this->_layout->getField($V972bf3f0);
-if (FileMaker::isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-switch ($V06e3d36f->getResult()) {
- case 'date': 
- $V78f0805f = explode('/', $V2063c160);
-if (count($V78f0805f) != 3) {
- return new FileMaker_Error($this->_fm, 'Failed to parse "' . $V2063c160 . '" as a FileMaker date value.');
-}
-$Vd7e6d55b = @mktime(0, 0, 0, $V78f0805f[0], $V78f0805f[1], $V78f0805f[2]);
-if ($Vd7e6d55b === false) {
- return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
-}
-break;
-case 'time': 
- $V78f0805f = explode(':', $V2063c160);
-if (count($V78f0805f) != 3) {
- return new FileMaker_Error($this->_fm, 'Failed to parse "' . $V2063c160 . '" as a FileMaker time value.');
-}
-$Vd7e6d55b = @mktime($V78f0805f[0], $V78f0805f[1], $V78f0805f[2], 1, 1, 1970);
-if ($Vd7e6d55b === false) {
- return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
-}
-break;
-case 'timestamp':  
- $Vd7e6d55b = @strtotime($V2063c160);
-if ($Vd7e6d55b === false) {
- return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
-}
-break;
-default:
- $Vd7e6d55b = new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be converted to UNIX timestamps.');
-break;
-}
-return $Vd7e6d55b;
-}
- function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0)
- {
- $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
-$this->V5e7ec2d5[$V06e3d36f][$V6d786dc7] = true;
-return $V2063c160;
-}
- function setFieldFromTimestamp($V972bf3f0, $Vd7e6d55b, $V6d786dc7 = 0)
- {
- $V06e3d36f = $this->_layout->getField($V972bf3f0);
-if (FileMaker::isError($V06e3d36f)) {
- return $V06e3d36f;
-}
-switch ($V06e3d36f->getResult()) {
- case 'date':
- return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
-case 'time':
- return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
-case 'timestamp':
- return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
-}
-return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
-}
- function getRecordId()
- {
- return $this->_recordId;
-}
- function getModificationId()
- {
- return $this->_modificationId;
-}
- function &getRelatedSet($Vaca007a7)
- {
- if (empty($this->_relatedSets[$Vaca007a7])) {
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'Related set "' . $Vaca007a7 . '" not present.');
-return $Vcb5e100e;
-}
-return $this->_relatedSets[$Vaca007a7];
-}
- function &newRelatedRecord(&$Vd0e45878, $Vaca007a7)
- {
- $V3a2d7564 =& $this->_layout->getRelatedSet($Vaca007a7);
-if (FileMaker::isError($V3a2d7564)) {
- return $V3a2d7564;
-}
-$Vde17f0f2 = new FileMaker_Record($V3a2d7564);
-$Vde17f0f2->_impl->_parent =& $Vd0e45878;
-return $Vde17f0f2;
-}
- function &getParent()
- {
- return $this->_parent;
-}
- function validate($V972bf3f0 = null)
- {
- $V1dccadfe =& $this->_fm->newAddCommand($this->_layout->getName(), $this->_fields);
-return $V1dccadfe->validate($V972bf3f0);
-}
- function commit()
- {  
- if ($this->_fm->getProperty('prevalidate')) {
- $V9f7d0ee8 = $this->validate();
-if (FileMaker::isError($V9f7d0ee8)) {
- return $V9f7d0ee8;
-}
-}   
- if (is_null($this->_parent)) {
- if ($this->_recordId) {
- return $this->_commitEdit();
-} else {
- return $this->_commitAdd();
-}
-} else {    
- if (!$this->_parent->getRecordId()) {
- return new FileMaker_Error($this->_fm, 'You must commit the parent record first before you can commit its children.');
-}
-if ($this->_recordId) {
- return $this->_commitEditChild();
-} else {
- return $this->_commitAddChild();
-}
-}
-}
- function delete()
- {
- if (empty($this->_recordId)) {
- return new FileMaker_Error($this->_fm, 'You cannot delete a record that does not exist on the server.');
-} 
- if ($this->_parent) {
- $Vd05b6ed7 = array(); 
- $V1dccadfe =& $this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
- $this->_parent->_impl->_recordId,
- $Vd05b6ed7); 
- $V1dccadfe->_impl->_setdeleteRelated($this->_layout->getName().".".$this->_recordId);
+    public function getFieldUnencoded($V06e3d36f, $V6d786dc7 = 0)
+    {
+        if (!isset($this->_fields[$V06e3d36f])) {
+            $this->_fm->log('Field "' . $V06e3d36f . '" not found.', FILEMAKER_LOG_INFO);
+            return "";
+        }
+        if (!isset($this->_fields[$V06e3d36f][$V6d786dc7])) {
+            $this->_fm->log('Repetition "' . (int) $V6d786dc7 . '" does not exist for "' . $V06e3d36f . '".', FILEMAKER_LOG_INFO);
+            return "";
+        }
+        return $this->_fields[$V06e3d36f][$V6d786dc7];
+    }
+    public function getFieldAsTimestamp($V972bf3f0, $V6d786dc7 = 0)
+    {
+        $V2063c160 = $this->getField($V972bf3f0, $V6d786dc7);
+        if (FileMaker::isError($V2063c160)) {
+            return $V2063c160;
+        }
+        $V06e3d36f = &$this->_layout->getField($V972bf3f0);
+        if (FileMaker::isError($V06e3d36f)) {
+            return $V06e3d36f;
+        }
+        switch ($V06e3d36f->getResult()) {
+            case 'date':
+                $V78f0805f = explode('/', $V2063c160);
+                if (count($V78f0805f) != 3) {
+                    return new FileMaker_Error($this->_fm, 'Failed to parse "' . $V2063c160 . '" as a FileMaker date value.');
+                }
+                $Vd7e6d55b = @mktime(0, 0, 0, $V78f0805f[0], $V78f0805f[1], $V78f0805f[2]);
+                if ($Vd7e6d55b === false) {
+                    return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
+                }
+                break;
+            case 'time':
+                $V78f0805f = explode(':', $V2063c160);
+                if (count($V78f0805f) != 3) {
+                    return new FileMaker_Error($this->_fm, 'Failed to parse "' . $V2063c160 . '" as a FileMaker time value.');
+                }
+                $Vd7e6d55b = @mktime($V78f0805f[0], $V78f0805f[1], $V78f0805f[2], 1, 1, 1970);
+                if ($Vd7e6d55b === false) {
+                    return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
+                }
+                break;
+            case 'timestamp':
+                $Vd7e6d55b = @strtotime($V2063c160);
+                if ($Vd7e6d55b === false) {
+                    return new FileMaker_Error($this->_fm, 'Failed to convert "' . $V2063c160 . '" to a UNIX timestamp.');
+                }
+                break;
+            default:
+                $Vd7e6d55b = new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be converted to UNIX timestamps.');
+                break;
+        }
+        return $Vd7e6d55b;
+    }
+    public function setField($V06e3d36f, $V2063c160, $V6d786dc7 = 0)
+    {
+        $this->_fields[$V06e3d36f][$V6d786dc7] = $V2063c160;
+        $this->V5e7ec2d5[$V06e3d36f][$V6d786dc7] = true;
+        return $V2063c160;
+    }
+    public function setFieldFromTimestamp($V972bf3f0, $Vd7e6d55b, $V6d786dc7 = 0)
+    {
+        $V06e3d36f = $this->_layout->getField($V972bf3f0);
+        if (FileMaker::isError($V06e3d36f)) {
+            return $V06e3d36f;
+        }
+        switch ($V06e3d36f->getResult()) {
+            case 'date':
+                return $this->setField($V972bf3f0, date('m/d/Y', $Vd7e6d55b), $V6d786dc7);
+            case 'time':
+                return $this->setField($V972bf3f0, date('H:i:s', $Vd7e6d55b), $V6d786dc7);
+            case 'timestamp':
+                return $this->setField($V972bf3f0, date('m/d/Y H:i:s', $Vd7e6d55b), $V6d786dc7);
+        }
+        return new FileMaker_Error($this->_fm, 'Only time, date, and timestamp fields can be set to the value of a timestamp.');
+    }
+    public function getRecordId()
+    {
+        return $this->_recordId;
+    }
+    public function getModificationId()
+    {
+        return $this->_modificationId;
+    }
+    public function &getRelatedSet($Vaca007a7)
+    {
+        if (empty($this->_relatedSets[$Vaca007a7])) {
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Related set "' . $Vaca007a7 . '" not present.');
+            return $Vcb5e100e;
+        }
+        return $this->_relatedSets[$Vaca007a7];
+    }
+    public function &newRelatedRecord(&$Vd0e45878, $Vaca007a7)
+    {
+        $V3a2d7564 = &$this->_layout->getRelatedSet($Vaca007a7);
+        if (FileMaker::isError($V3a2d7564)) {
+            return $V3a2d7564;
+        }
+        $Vde17f0f2 = new FileMaker_Record($V3a2d7564);
+        $Vde17f0f2->_impl->_parent = &$Vd0e45878;
+        return $Vde17f0f2;
+    }
+    public function &getParent()
+    {
+        return $this->_parent;
+    }
+    public function validate($V972bf3f0 = null)
+    {
+        $V1dccadfe = &$this->_fm->newAddCommand($this->_layout->getName(), $this->_fields);
+        return $V1dccadfe->validate($V972bf3f0);
+    }
+    public function commit()
+    {
+        if ($this->_fm->getProperty('prevalidate')) {
+            $V9f7d0ee8 = $this->validate();
+            if (FileMaker::isError($V9f7d0ee8)) {
+                return $V9f7d0ee8;
+            }
+        }
+        if (is_null($this->_parent)) {
+            if ($this->_recordId) {
+                return $this->_commitEdit();
+            } else {
+                return $this->_commitAdd();
+            }
+        } else {
+            if (!$this->_parent->getRecordId()) {
+                return new FileMaker_Error($this->_fm, 'You must commit the parent record first before you can commit its children.');
+            }
+            if ($this->_recordId) {
+                return $this->_commitEditChild();
+            } else {
+                return $this->_commitAddChild();
+            }
+        }
+    }
+    public function delete()
+    {
+        if (empty($this->_recordId)) {
+            return new FileMaker_Error($this->_fm, 'You cannot delete a record that does not exist on the server.');
+        }
+        if ($this->_parent) {
+            $Vd05b6ed7 = array();
+            $V1dccadfe = &$this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
+                $this->_parent->_impl->_recordId,
+                $Vd05b6ed7);
+            $V1dccadfe->_impl->_setdeleteRelated($this->_layout->getName() . "." . $this->_recordId);
 
- return $V1dccadfe->execute();
-} 
- else {
- $Vc6140495 = $this->_layout->getName();
+            return $V1dccadfe->execute();
+        } else {
+            $Vc6140495 = $this->_layout->getName();
 
- $V1dccadfe =& $this->_fm->newDeleteCommand($Vc6140495, $this->_recordId);
-return $V1dccadfe->execute();
-}
-}
- function _commitAdd()
- { 
- $V1dccadfe =& $this->_fm->newAddCommand($this->_layout->getName(), $this->_fields);
-$Vd1fc8eaf = $V1dccadfe->execute();
-if (FileMaker::isError($Vd1fc8eaf)) {
- return $Vd1fc8eaf;
-} 
- $V6e52c40b =& $Vd1fc8eaf->getRecords();
-return $this->_updateFrom($V6e52c40b[0]);
-}
- function _commitEdit()
- {  
- foreach ($this->_fields as $V972bf3f0 => $Vd4680e80) {
- foreach ($Vd4680e80 as $V6d786dc7 => $V2063c160) {
- if (isset($this->V5e7ec2d5[$V972bf3f0][$V6d786dc7])) {
- $V8977dfac[$V972bf3f0][$V6d786dc7] = $V2063c160;
-}
-}
-}
-$V1dccadfe =& $this->_fm->newEditCommand($this->_layout->getName(),
- $this->_recordId,
- $V8977dfac);
-$Vd1fc8eaf = $V1dccadfe->execute();
-if (FileMaker::isError($Vd1fc8eaf)) {
- return $Vd1fc8eaf;
-} 
- $V6e52c40b =& $Vd1fc8eaf->getRecords();
-return $this->_updateFrom($V6e52c40b[0]);
-}
- function _commitAddChild()
- {  
- $Vd05b6ed7 = array();
-foreach ($this->_fields as $Vb068931c => $Vee0525e4) {
- $Vd05b6ed7[$Vb068931c . '.0'] = $Vee0525e4;
-} 
- $V1dccadfe =& $this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
- $this->_parent->getRecordId(),
- $Vd05b6ed7);
-$Vd1fc8eaf = $V1dccadfe->execute();
-if (FileMaker::isError($Vd1fc8eaf)) {
- return $Vd1fc8eaf;
-} 
- $V6e52c40b =& $Vd1fc8eaf->getRecords();
-$Vd0e45878 =& $V6e52c40b[0];
-$V268184c1 =& $Vd0e45878->getRelatedSet($this->_layout->getName());
-$V98bd1c45 = array_pop($V268184c1);
-return $this->_updateFrom($V98bd1c45);
-}
- function _commitEditChild()
- {  
- foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
- foreach ($Vee0525e4 as $V6d786dc7 => $V2063c160) {
- if (!empty($this->V5e7ec2d5[$V972bf3f0][$V6d786dc7])) {
- $V8977dfac[$V972bf3f0 . '.' . $this->_recordId][$V6d786dc7] = $V2063c160;
-}
-}
-}
-$V1dccadfe =& $this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
- $this->_parent->getRecordId(),
- $V8977dfac);
-$Vd1fc8eaf = $V1dccadfe->execute();
-if (FileMaker::isError($Vd1fc8eaf)) {
- return $Vd1fc8eaf;
-} 
- $V6e52c40b =& $Vd1fc8eaf->getRecords();
-$Vd0e45878 =& $V6e52c40b[0];
-$V268184c1 =& $Vd0e45878->getRelatedSet($this->_layout->getName());
-foreach ($V268184c1 as $V1b7d5726) {
- if ($V1b7d5726->getRecordId() == $this->_recordId) {
- return $this->_updateFrom($V1b7d5726);
-break;
-}
-}
-return new FileMaker_Error('Failed to find the updated child in the response.');
-}
- function _updateFrom(&$Vde17f0f2)
- {
- $this->_recordId = $Vde17f0f2->getRecordId();
-$this->_modificationId = $Vde17f0f2->getModificationId();
-$this->_fields = $Vde17f0f2->_impl->_fields;
-$this->_layout =& $Vde17f0f2->_impl->_layout;
-$this->_relatedSets =& $Vde17f0f2->_impl->_relatedSets; 
- $this->V5e7ec2d5= array();
-return true;
-}
+            $V1dccadfe = &$this->_fm->newDeleteCommand($Vc6140495, $this->_recordId);
+            return $V1dccadfe->execute();
+        }
+    }
+    public function _commitAdd()
+    {
+        $V1dccadfe = &$this->_fm->newAddCommand($this->_layout->getName(), $this->_fields);
+        $Vd1fc8eaf = $V1dccadfe->execute();
+        if (FileMaker::isError($Vd1fc8eaf)) {
+            return $Vd1fc8eaf;
+        }
+        $V6e52c40b = &$Vd1fc8eaf->getRecords();
+        return $this->_updateFrom($V6e52c40b[0]);
+    }
+    public function _commitEdit()
+    {
+        foreach ($this->_fields as $V972bf3f0 => $Vd4680e80) {
+            foreach ($Vd4680e80 as $V6d786dc7 => $V2063c160) {
+                if (isset($this->V5e7ec2d5[$V972bf3f0][$V6d786dc7])) {
+                    $V8977dfac[$V972bf3f0][$V6d786dc7] = $V2063c160;
+                }
+            }
+        }
+        $V1dccadfe = &$this->_fm->newEditCommand($this->_layout->getName(),
+            $this->_recordId,
+            $V8977dfac);
+        $Vd1fc8eaf = $V1dccadfe->execute();
+        if (FileMaker::isError($Vd1fc8eaf)) {
+            return $Vd1fc8eaf;
+        }
+        $V6e52c40b = &$Vd1fc8eaf->getRecords();
+        return $this->_updateFrom($V6e52c40b[0]);
+    }
+    public function _commitAddChild()
+    {
+        $Vd05b6ed7 = array();
+        foreach ($this->_fields as $Vb068931c => $Vee0525e4) {
+            $Vd05b6ed7[$Vb068931c . '.0'] = $Vee0525e4;
+        }
+        $V1dccadfe = &$this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
+            $this->_parent->getRecordId(),
+            $Vd05b6ed7);
+        $Vd1fc8eaf = $V1dccadfe->execute();
+        if (FileMaker::isError($Vd1fc8eaf)) {
+            return $Vd1fc8eaf;
+        }
+        $V6e52c40b = &$Vd1fc8eaf->getRecords();
+        $Vd0e45878 = &$V6e52c40b[0];
+        $V268184c1 = &$Vd0e45878->getRelatedSet($this->_layout->getName());
+        $V98bd1c45 = array_pop($V268184c1);
+        return $this->_updateFrom($V98bd1c45);
+    }
+    public function _commitEditChild()
+    {
+        foreach ($this->_fields as $V972bf3f0 => $Vee0525e4) {
+            foreach ($Vee0525e4 as $V6d786dc7 => $V2063c160) {
+                if (!empty($this->V5e7ec2d5[$V972bf3f0][$V6d786dc7])) {
+                    $V8977dfac[$V972bf3f0 . '.' . $this->_recordId][$V6d786dc7] = $V2063c160;
+                }
+            }
+        }
+        $V1dccadfe = &$this->_fm->newEditCommand($this->_parent->_impl->_layout->getName(),
+            $this->_parent->getRecordId(),
+            $V8977dfac);
+        $Vd1fc8eaf = $V1dccadfe->execute();
+        if (FileMaker::isError($Vd1fc8eaf)) {
+            return $Vd1fc8eaf;
+        }
+        $V6e52c40b = &$Vd1fc8eaf->getRecords();
+        $Vd0e45878 = &$V6e52c40b[0];
+        $V268184c1 = &$Vd0e45878->getRelatedSet($this->_layout->getName());
+        foreach ($V268184c1 as $V1b7d5726) {
+            if ($V1b7d5726->getRecordId() == $this->_recordId) {
+                return $this->_updateFrom($V1b7d5726);
+                break;
+            }
+        }
+        return new FileMaker_Error('Failed to find the updated child in the response.');
+    }
+    public function _updateFrom(&$Vde17f0f2)
+    {
+        $this->_recordId = $Vde17f0f2->getRecordId();
+        $this->_modificationId = $Vde17f0f2->getModificationId();
+        $this->_fields = $Vde17f0f2->_impl->_fields;
+        $this->_layout = &$Vde17f0f2->_impl->_layout;
+        $this->_relatedSets = &$Vde17f0f2->_impl->_relatedSets;
+        $this->V5e7ec2d5 = array();
+        return true;
+    }
 
-  function getRelatedRecordById($V97f7e518, $Va6ec9c02)
- {
- 
- $Vaca007a7 = $this->getRelatedSet($V97f7e518);
-if(FileMaker::IsError($Vaca007a7)){
- 
- $Vcb5e100e = new FileMaker_Error($this->_fm, 'Related set "' . $Vaca007a7 . '" not present.');
-return $Vcb5e100e;
-}else{ 
-  foreach ($Vaca007a7 as $V1b7d5726) {
- if( $V1b7d5726->getRecordId() == $Va6ec9c02){
- return $V1b7d5726;
-}
-}
-$Vcb5e100e = new FileMaker_Error($this->_fm, 'Record not present.');
-return $Vcb5e100e;	
- 
- } 
- }
+    public function getRelatedRecordById($V97f7e518, $Va6ec9c02)
+    {
+
+        $Vaca007a7 = $this->getRelatedSet($V97f7e518);
+        if (FileMaker::IsError($Vaca007a7)) {
+
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Related set "' . $Vaca007a7 . '" not present.');
+            return $Vcb5e100e;
+        } else {
+            foreach ($Vaca007a7 as $V1b7d5726) {
+                if ($V1b7d5726->getRecordId() == $Va6ec9c02) {
+                    return $V1b7d5726;
+                }
+            }
+            $Vcb5e100e = new FileMaker_Error($this->_fm, 'Record not present.');
+            return $Vcb5e100e;
+
+        }
+    }
 
 }

--- a/src/FMAPI/FileMaker/Implementation/RelatedSetImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/RelatedSetImpl.php
@@ -1,37 +1,37 @@
 <?php
-  class FileMaker_RelatedSet_Implementation
+class FileMaker_RelatedSet_Implementation
 {
-  var $_layout;
- var $_fm;
- var $_name;
- var $_fields = array();
- function FileMaker_RelatedSet_Implementation(&$Vc6140495)
- {
- $this->_layout =& $Vc6140495;
-$this->_fm =& $Vc6140495->_impl->_fm;
-}
- function getName()
- {
- return $this->_name;
-}
- function listFields()
- {
- return array_keys($this->_fields);
-}
- function &getField($V972bf3f0)
- {
- if (isset($this->_fields[$V972bf3f0])) {
- return $this->_fields[$V972bf3f0];
-}
-$Vcb5e100e = new FileMaker_Error($this->_fm, 'Field Not Found');
-return $Vcb5e100e;
-}
- function &getFields()
- {
- return $this->_fields;
-}
- function loadExtendedInfo()
- {
- return new FileMaker_Error($this->_fm, 'Related sets do not support extended information.');
-}
+    public $_layout;
+    public $_fm;
+    public $_name;
+    public $_fields = array();
+    public function __construct(&$Vc6140495)
+    {
+        $this->_layout = &$Vc6140495;
+        $this->_fm = &$Vc6140495->_impl->_fm;
+    }
+    public function getName()
+    {
+        return $this->_name;
+    }
+    public function listFields()
+    {
+        return array_keys($this->_fields);
+    }
+    public function &getField($V972bf3f0)
+    {
+        if (isset($this->_fields[$V972bf3f0])) {
+            return $this->_fields[$V972bf3f0];
+        }
+        $Vcb5e100e = new FileMaker_Error($this->_fm, 'Field Not Found');
+        return $Vcb5e100e;
+    }
+    public function &getFields()
+    {
+        return $this->_fields;
+    }
+    public function loadExtendedInfo()
+    {
+        return new FileMaker_Error($this->_fm, 'Related sets do not support extended information.');
+    }
 }

--- a/src/FMAPI/FileMaker/Implementation/ResultImpl.php
+++ b/src/FMAPI/FileMaker/Implementation/ResultImpl.php
@@ -1,52 +1,52 @@
 <?php
-  class FileMaker_Result_Implementation
+class FileMaker_Result_Implementation
 {
-  var $_fm;
- var $_layout;
- var $_records;
- var $_tableCount;
- var $_foundSetCount;
- var $_fetchCount;
- function FileMaker_Result_Implementation(&$V0ab34ca9)
- {
- $this->_fm = &$V0ab34ca9;
-}
- function &getLayout()
- {
- return $this->_layout;
-}
- function &getRecords()
- {
- return $this->_records;
-}
- function getFields()
- {
- return $this->_layout->listFields();
-}
- function getRelatedSets()
- {
- return $this->_layout->listRelatedSets();
-}
- function getTableRecordCount()
- {
- return $this->_tableCount;
-}
- function getFoundSetCount()
- {
- return $this->_foundSetCount;
-}
- function getFetchCount()
- {
- return $this->_fetchCount;
-}
+    public $_fm;
+    public $_layout;
+    public $_records;
+    public $_tableCount;
+    public $_foundSetCount;
+    public $_fetchCount;
+    public function __construct(&$V0ab34ca9)
+    {
+        $this->_fm = &$V0ab34ca9;
+    }
+    public function &getLayout()
+    {
+        return $this->_layout;
+    }
+    public function &getRecords()
+    {
+        return $this->_records;
+    }
+    public function getFields()
+    {
+        return $this->_layout->listFields();
+    }
+    public function getRelatedSets()
+    {
+        return $this->_layout->listRelatedSets();
+    }
+    public function getTableRecordCount()
+    {
+        return $this->_tableCount;
+    }
+    public function getFoundSetCount()
+    {
+        return $this->_foundSetCount;
+    }
+    public function getFetchCount()
+    {
+        return $this->_fetchCount;
+    }
 
-  function getFirstRecord()
- {
- return $this->_records[0];
-}
+    public function getFirstRecord()
+    {
+        return $this->_records[0];
+    }
 
-  function getLastRecord()
- {
- return $this->_records[sizeof($this->_records)-1];
-}
+    public function getLastRecord()
+    {
+        return $this->_records[sizeof($this->_records) - 1];
+    }
 }

--- a/src/FMAPI/FileMaker/Layout.php
+++ b/src/FMAPI/FileMaker/Layout.php
@@ -36,15 +36,15 @@ class FileMaker_Layout
      * @var FileMaker_Layout_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Layout object constructor.
      *
-     * @param FileMaker_Implementation &$fm FileMaker_Implementation object 
+     * @param FileMaker_Implementation &$fm FileMaker_Implementation object
      *        that this layout was created through.
      */
-    function FileMaker_Layout(&$fm)
+    public function __construct(&$fm)
     {
         $this->_impl = new FileMaker_Layout_Implementation($fm);
     }
@@ -54,7 +54,7 @@ class FileMaker_Layout
      *
      * @return string Layout name.
      */
-    function getName()
+    public function getName()
     {
         return $this->_impl->getName();
     }
@@ -64,7 +64,7 @@ class FileMaker_Layout
      *
      * @return string Database name.
      */
-    function getDatabase()
+    public function getDatabase()
     {
         return $this->_impl->getDatabase();
     }
@@ -74,7 +74,7 @@ class FileMaker_Layout
      *
      * @return array List of field names as strings.
      */
-    function listFields()
+    public function listFields()
     {
         return $this->_impl->listFields();
     }
@@ -84,10 +84,10 @@ class FileMaker_Layout
      *
      * @param string $fieldName Name of field.
      *
-     * @return FileMaker_Field|FileMaker_Error Field object, if successful. 
+     * @return FileMaker_Field|FileMaker_Error Field object, if successful.
      *         Otherwise, an Error object.
      */
-    function getField($fieldName)
+    public function getField($fieldName)
     {
         return $this->_impl->getField($fieldName);
     }
@@ -98,7 +98,7 @@ class FileMaker_Layout
      *
      * @return array Array of {@link FileMaker_Field} objects.
      */
-    function &getFields()
+    public function &getFields()
     {
         return $this->_impl->getFields();
     }
@@ -109,32 +109,32 @@ class FileMaker_Layout
      *
      * @return array List of related table names as strings.
      */
-    function listRelatedSets()
+    public function listRelatedSets()
     {
         return $this->_impl->listRelatedSets();
     }
 
     /**
-     * Returns a FileMaker_RelatedSet object that describes the specified 
+     * Returns a FileMaker_RelatedSet object that describes the specified
      * portal.
      *
      * @param string $relatedSet Name of the related table for a portal.
      *
-     * @return FileMaker_RelatedSet|FileMaker_Error RelatedSet object, if 
+     * @return FileMaker_RelatedSet|FileMaker_Error RelatedSet object, if
      *         successful. Otherwise, an Error object.
      */
-    function &getRelatedSet($relatedSet)
+    public function &getRelatedSet($relatedSet)
     {
         return $this->_impl->getRelatedSet($relatedSet);
     }
 
     /**
-     * Returns an associative array with the related table names of all 
+     * Returns an associative array with the related table names of all
      * portals as keys and FileMaker_RelatedSet objects as the array values.
      *
      * @return array Array of {@link FileMaker_RelatedSet} objects.
      */
-    function &getRelatedSets()
+    public function &getRelatedSets()
     {
         return $this->_impl->getRelatedSets();
     }
@@ -145,7 +145,7 @@ class FileMaker_Layout
      *
      * @return array List of value list names as strings.
      */
-    function listValueLists()
+    public function listValueLists()
     {
         return $this->_impl->listValueLists();
     }
@@ -154,7 +154,7 @@ class FileMaker_Layout
      * Returns the list of defined values in the specified value list.
      *
      * @param string $valueList Name of value list.
-     * @param string  $recid Record from which the value list should be 
+     * @param string  $recid Record from which the value list should be
      *        displayed.
      *
      * @return array List of defined values.
@@ -163,37 +163,34 @@ class FileMaker_Layout
 
      * @see getValueListTwoFields
      */
-    function getValueList($valueList, $recid = null)
+    public function getValueList($valueList, $recid = null)
     {
         return $this->_impl->getValueList($valueList, $recid);
     }
 
-    
-
     /**
 
-     * Returns the list of defined values in the specified value list. 
+     * Returns the list of defined values in the specified value list.
 
-     * This method supports single, 2nd only, and both fields value lists. 
+     * This method supports single, 2nd only, and both fields value lists.
 
      *
 
      * @param string $valueList Name of value list.
 
-     * @param string  $recid Record from which the value list should be 
+     * @param string  $recid Record from which the value list should be
 
      *        displayed.
 
      *
 
-     * @return array of display names and its corresponding 
+     * @return array of display names and its corresponding
 
      * value from the value list.
 
      */
 
-    function getValueListTwoFields($valueList, $recid = null)
-
+    public function getValueListTwoFields($valueList, $recid = null)
     {
 
         return $this->_impl->getValueListTwoFields($valueList, $recid);
@@ -201,51 +198,48 @@ class FileMaker_Layout
     }
 
     /**
-     * Returns a multi-level associative array of value lists. 
-     * The top-level array has names of value lists as keys and arrays as 
-     * values. The second level arrays are the lists of defined values from 
+     * Returns a multi-level associative array of value lists.
+     * The top-level array has names of value lists as keys and arrays as
+     * values. The second level arrays are the lists of defined values from
      * each value list.
      *
-     * @param string  $recid Record from which the value list should be 
+     * @param string  $recid Record from which the value list should be
      *        displayed.
-     * 
+     *
      * @return array Array of value-list arrays.
 
      * @deprecated Use getValueListTwoFields instead.
 
      * @see getValueListsTwoFields
      */
-    function getValueLists($recid = null)
+    public function getValueLists($recid = null)
     {
         return $this->_impl->getValueLists($recid);
     }
 
-    
-
     /**
 
-     * Returns a multi-level associative array of value lists. 
+     * Returns a multi-level associative array of value lists.
 
-     * The top-level array has names of value lists as keys and associative arrays as 
+     * The top-level array has names of value lists as keys and associative arrays as
 
-     * values. The second level associative arrays are lists of display name and its corresponding 
+     * values. The second level associative arrays are lists of display name and its corresponding
 
      * value from the value list.
 
      *
 
-     * @param string  $recid Record from which the value list should be 
+     * @param string  $recid Record from which the value list should be
 
      *        displayed.
 
-     * 
+     *
 
      * @return array Array of value-list associative arrays.
 
      */
 
-    function getValueListsTwoFields($recid = null)
-
+    public function getValueListsTwoFields($recid = null)
     {
 
         return $this->_impl->getValueListsTwoFields($recid);
@@ -257,12 +251,12 @@ class FileMaker_Layout
      *
      * @access private
      *
-     * @param string  $recid Record from which to load extended information. 
+     * @param string  $recid Record from which to load extended information.
      *
-     * @return boolean|FileMaker_Error TRUE, if successful. Otherwise, an 
+     * @return boolean|FileMaker_Error TRUE, if successful. Otherwise, an
      *         Error object.
      */
-    function loadExtendedInfo($recid = null)
+    public function loadExtendedInfo($recid = null)
     {
         return $this->_impl->loadExtendedInfo($recid);
     }

--- a/src/FMAPI/FileMaker/PEAR.php
+++ b/src/FMAPI/FileMaker/PEAR.php
@@ -167,7 +167,7 @@ class PEAR
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {

--- a/src/FMAPI/FileMaker/Record.php
+++ b/src/FMAPI/FileMaker/Record.php
@@ -20,21 +20,21 @@ require_once dirname(__FILE__) . '/Implementation/RecordImpl.php';
 /**#@-*/
 
 /**
- * Default Record class that represents each record of a result set. 
- * 
- * From a Record object, you can get field data, edit and delete the record, 
- * get its parent record, get its related record set, and create related 
- * records. 
- * 
- * Instead of this class, you can specify a different class to use for Record 
- * objects. To specify the record class to use, open the 
- * FileMaker/conf/filemaker-api.php configuration file where the API is 
- * installed. Then set $__FM_CONFIG['recordClass'] to the name of the record 
- * class to use. The class you specify should be a subclass of the 
- * FileMaker_Record base class or encapsulate its functionality. In PHP 5, 
- * this class would implement an interface that alternate classes would be 
- * required to implement as well. 
- * 
+ * Default Record class that represents each record of a result set.
+ *
+ * From a Record object, you can get field data, edit and delete the record,
+ * get its parent record, get its related record set, and create related
+ * records.
+ *
+ * Instead of this class, you can specify a different class to use for Record
+ * objects. To specify the record class to use, open the
+ * FileMaker/conf/filemaker-api.php configuration file where the API is
+ * installed. Then set $__FM_CONFIG['recordClass'] to the name of the record
+ * class to use. The class you specify should be a subclass of the
+ * FileMaker_Record base class or encapsulate its functionality. In PHP 5,
+ * this class would implement an interface that alternate classes would be
+ * required to implement as well.
+ *
  * @package FileMaker
  */
 class FileMaker_Record
@@ -45,16 +45,16 @@ class FileMaker_Record
      * @var FileMaker_Record_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Record object constructor.
      *
-     * @param FileMaker_Layout|FileMaker_RelatedSet Specify either the Layout 
-     *        object associated with this record or the Related Set object 
+     * @param FileMaker_Layout|FileMaker_RelatedSet Specify either the Layout
+     *        object associated with this record or the Related Set object
      *        that this record is a member of.
      */
-    function FileMaker_Record(&$layout)
+    public function __construct(&$layout)
     {
         $this->_impl = new FileMaker_Record_Implementation($layout);
     }
@@ -64,21 +64,21 @@ class FileMaker_Record
      *
      * @return FileMaker_Layout This record's layout.
      */
-    function &getLayout()
+    public function &getLayout()
     {
         return $this->_impl->getLayout();
     }
 
     /**
-     * Returns a list of the names of all fields in the record. 
+     * Returns a list of the names of all fields in the record.
      *
-     * Only the field names are returned. If you need additional 
-     * information, examine the Layout object provided by the 
-     * parent object's {@link FileMaker_Result::getLayout()} method.  
+     * Only the field names are returned. If you need additional
+     * information, examine the Layout object provided by the
+     * parent object's {@link FileMaker_Result::getLayout()} method.
      *
      * @return array List of field names as strings.
      */
-    function getFields()
+    public function getFields()
     {
         return $this->_impl->getFields();
     }
@@ -86,42 +86,42 @@ class FileMaker_Record
     /**
      * Returns the HTML-encoded value of the specified field.
      *
-     * This method converts some special characters in the field value to 
-     * HTML entities. For example, '&', '"', '<', and '>' are converted to 
+     * This method converts some special characters in the field value to
+     * HTML entities. For example, '&', '"', '<', and '>' are converted to
      * '&amp;', '&quot;', '&lt;', and '&gt;', respectively.
      *
      * @param string $field Name of field.
-     * @param integer $repetition Field repetition number to get. 
+     * @param integer $repetition Field repetition number to get.
      *        Defaults to the first repetition.
      *
      * @return string Encoded field value.
      */
-    function getField($field, $repetition = 0)
+    public function getField($field, $repetition = 0)
     {
         return $this->_impl->getField($field, $repetition);
     }
-    
-	/**
+
+    /**
      * Returns the unencoded value of the specified field.
      *
-     * This method does not convert special characters in the field value to 
+     * This method does not convert special characters in the field value to
      * HTML entities.
      *
      * @param string $field Name of field.
-     * @param integer $repetition Field repetition number to get. 
+     * @param integer $repetition Field repetition number to get.
      *        Defaults to the first repetition.
      *
      * @return string Unencoded field value.
      */
-    function getFieldUnencoded($field, $repetition = 0)
+    public function getFieldUnencoded($field, $repetition = 0)
     {
         return $this->_impl->getFieldUnencoded($field, $repetition);
     }
 
     /**
-     * Returns the value of the specified field as a UNIX 
-     * timestamp. 
-     * 
+     * Returns the value of the specified field as a UNIX
+     * timestamp.
+     *
      * If the field is a date field, the timestamp is
      * for the field date at midnight. It the field is a time field,
      * the timestamp is for that time on January 1, 1970. Timestamp
@@ -129,14 +129,14 @@ class FileMaker_Record
      * specified field is not a date or time field, or if the timestamp
      * generated would be out of range, then this method returns a
      * FileMaker_Error object instead.
-     * 
+     *
      * @param string $field Name of the field.
-     * @param integer $repetition Field repetition number to get. 
+     * @param integer $repetition Field repetition number to get.
      *        Defaults to the first repetition.
      *
      * @return integer Timestamp value.
      */
-    function getFieldAsTimestamp($field, $repetition = 0)
+    public function getFieldAsTimestamp($field, $repetition = 0)
     {
         return $this->_impl->getFieldAsTimestamp($field, $repetition);
     }
@@ -146,31 +146,31 @@ class FileMaker_Record
      *
      * @param string $field Name of the field.
      * @param string $value New value of the field.
-     * @param integer $repetition Field repetition number to set. 
+     * @param integer $repetition Field repetition number to set.
      *        Defaults to the first repetition.
      */
-    function setField($field, $value, $repetition = 0)
+    public function setField($field, $value, $repetition = 0)
     {
         return $this->_impl->setField($field, $value, $repetition);
     }
 
     /**
      * Sets the new value for a date, time, or timestamp field from a
-     * UNIX timestamp value. 
+     * UNIX timestamp value.
      *
-     * If the field is not a date or time field, then returns an error. 
+     * If the field is not a date or time field, then returns an error.
      * Otherwise, returns TRUE.
      *
-     * If layout data for the target of this command has not already 
+     * If layout data for the target of this command has not already
      * been loaded, calling this method loads layout data so that
      * the type of the field can be checked.
      *
      * @param string $field Name of the field to set.
      * @param string $timestamp Timestamp value.
-     * @param integer $repetition Field repetition number to set. 
+     * @param integer $repetition Field repetition number to set.
      *        Defaults to the first repetition.
      */
-    function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
+    public function setFieldFromTimestamp($field, $timestamp, $repetition = 0)
     {
         return $this->_impl->setFieldFromTimestamp($field, $timestamp, $repetition);
     }
@@ -180,21 +180,21 @@ class FileMaker_Record
      *
      * @return string Record ID.
      */
-    function getRecordId()
+    public function getRecordId()
     {
         return $this->_impl->getRecordId();
     }
 
     /**
      * Returns the modification ID of this record.
-     * 
-     * The modification ID is an incremental counter that specifies the current 
-     * version of a record. See the {@link FileMaker_Command_Edit::setModificationId()} 
+     *
+     * The modification ID is an incremental counter that specifies the current
+     * version of a record. See the {@link FileMaker_Command_Edit::setModificationId()}
      * method.
      *
      * @return integer Modification ID.
      */
-    function getModificationId()
+    public function getModificationId()
     {
         return $this->_impl->getModificationId();
     }
@@ -207,7 +207,7 @@ class FileMaker_Record
      *
      * @return array Array of FileMaker_Record objects from $relatedSet|FileMaker_Error object.
      */
-    function &getRelatedSet($relatedSet)
+    public function &getRelatedSet($relatedSet)
     {
         return $this->_impl->getRelatedSet($relatedSet);
     }
@@ -219,7 +219,7 @@ class FileMaker_Record
      *
      * @return FileMaker_Record A new, blank record.
      */
-    function &newRelatedRecord($relatedSet)
+    public function &newRelatedRecord($relatedSet)
     {
         return $this->_impl->newRelatedRecord($this, $relatedSet);
     }
@@ -229,34 +229,34 @@ class FileMaker_Record
      *
      * @return FileMaker_Record Parent record.
      */
-    function &getParent()
+    public function &getParent()
     {
         return $this->_impl->getParent();
     }
 
     /**
      * Pre-validates either a single field or the entire record.
-     * 
-     * This method uses the pre-validation rules that are enforceable by the 
-     * PHP engine -- for example, type rules, ranges, and four-digit dates. 
-     * Rules such as "unique" or "existing," or validation by calculation 
+     *
+     * This method uses the pre-validation rules that are enforceable by the
+     * PHP engine -- for example, type rules, ranges, and four-digit dates.
+     * Rules such as "unique" or "existing," or validation by calculation
      * field, cannot be pre-validated.
      *
-     * If you pass the optional $fieldName argument, only that field is 
+     * If you pass the optional $fieldName argument, only that field is
      * pre-validated. Otherwise, the record is pre-validated as if commit()
      * were called with "Enable record data pre-validation" selected in
-     * FileMaker Server Admin Console. If pre-validation passes, validate() 
-     * returns TRUE. If pre-validation fails, then validate() returns a 
-     * FileMaker_Error_Validation object containing details about what failed 
+     * FileMaker Server Admin Console. If pre-validation passes, validate()
+     * returns TRUE. If pre-validation fails, then validate() returns a
+     * FileMaker_Error_Validation object containing details about what failed
      * to pre-validate.
      *
-     * @param string $fieldName Name of field to pre-validate. If empty, 
+     * @param string $fieldName Name of field to pre-validate. If empty,
      *        pre-validates the entire record.
      *
-     * @return boolean|FileMaker_Error_Validation TRUE, if pre-validation 
+     * @return boolean|FileMaker_Error_Validation TRUE, if pre-validation
      *         passes for $value. Otherwise, an Error Validation object.
      */
-    function validate($fieldName = null)
+    public function validate($fieldName = null)
     {
         return $this->_impl->validate($fieldName);
     }
@@ -267,7 +267,7 @@ class FileMaker_Record
      * @return boolean|FileMaker_Error TRUE, if successful. Otherwise, an Error
      *         object.
      */
-    function commit()
+    public function commit()
     {
         return $this->_impl->commit();
     }
@@ -277,25 +277,24 @@ class FileMaker_Record
      *
      * @return FileMaker_Result Response object.
      */
-    function delete()
+    public function delete()
     {
         return $this->_impl->delete();
     }
-    
-    
+
     /**
-     * Gets a specific related record. 
+     * Gets a specific related record.
      *
      * @access private
      *
      * @param string $relatedSetName Name of the portal.
      * @param string $recordId Record ID of the record in the portal.
-     * 
+     *
      * @return FileMaker_Response Response object.
      */
-    function getRelatedRecordById($relatedSetName, $recordId)
-    {	
-    	return $this->_impl->getRelatedRecordById($relatedSetName, $recordId);	
+    public function getRelatedRecordById($relatedSetName, $recordId)
+    {
+        return $this->_impl->getRelatedRecordById($relatedSetName, $recordId);
     }
 
 }

--- a/src/FMAPI/FileMaker/RelatedSet.php
+++ b/src/FMAPI/FileMaker/RelatedSet.php
@@ -34,26 +34,26 @@ class FileMaker_RelatedSet
      * @var FileMaker_RelatedSet_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Portal constructor.
      *
-     * @param FileMaker_Layout &$layout FileMaker_Layout object that this 
+     * @param FileMaker_Layout &$layout FileMaker_Layout object that this
      * portal is on.
      */
-    function FileMaker_RelatedSet(&$layout)
+    public function __construct(&$layout)
     {
         $this->_impl = new FileMaker_RelatedSet_Implementation($layout);
     }
 
     /**
-     * Returns the name of the related table from which this portal displays 
+     * Returns the name of the related table from which this portal displays
      * related records.
      *
      * @return string Name of related table for this portal.
      */
-    function getName()
+    public function getName()
     {
         return $this->_impl->getName();
     }
@@ -63,7 +63,7 @@ class FileMaker_RelatedSet
      *
      * @return array List of field names as strings.
      */
-    function listFields()
+    public function listFields()
     {
         return $this->_impl->listFields();
     }
@@ -73,21 +73,21 @@ class FileMaker_RelatedSet
      *
      * @param string $fieldName Name of field.
      *
-     * @return FileMaker_Field|FileMaker_Error Field object, if successful. 
+     * @return FileMaker_Field|FileMaker_Error Field object, if successful.
      *         Otherwise, an Error object.
      */
-    function &getField($fieldName)
+    public function &getField($fieldName)
     {
         return $this->_impl->getField($fieldName);
     }
 
     /**
-     * Returns an associative array with the names of all fields as keys and 
+     * Returns an associative array with the names of all fields as keys and
      * FileMaker_Field objects as the array values.
      *
      * @return array Array of {@link FileMaker_Field} objects.
      */
-    function &getFields()
+    public function &getFields()
     {
         return $this->_impl->getFields();
     }
@@ -97,10 +97,10 @@ class FileMaker_RelatedSet
      *
      * @access private
      *
-     * @return boolean|FileMaker_Error TRUE, if successful. Otherwise, an Error 
+     * @return boolean|FileMaker_Error TRUE, if successful. Otherwise, an Error
      *         object.
      */
-    function loadExtendedInfo()
+    public function loadExtendedInfo()
     {
         return $this->_impl->loadExtendedInfo();
     }

--- a/src/FMAPI/FileMaker/Result.php
+++ b/src/FMAPI/FileMaker/Result.php
@@ -20,8 +20,8 @@ require_once dirname(__FILE__) . '/Implementation/ResultImpl.php';
 /**#@-*/
 
 /**
- * Result set description class. Contains all the information about a set of 
- * records returned by a command. 
+ * Result set description class. Contains all the information about a set of
+ * records returned by a command.
  *
  * @package FileMaker
  */
@@ -33,67 +33,67 @@ class FileMaker_Result
      * @var FileMaker_Result_Implementation
      * @access private
      */
-    var $_impl;
+    public $_impl;
 
     /**
      * Result object constructor.
      *
-     * @param FileMaker_Implementation &$fm FileMaker_Implementation object 
+     * @param FileMaker_Implementation &$fm FileMaker_Implementation object
      *        that this result came from.
      */
-    function FileMaker_Result(&$fm)
+    public function __construct(&$fm)
     {
         $this->_impl = new FileMaker_Result_Implementation($fm);
     }
 
     /**
-     * Returns a FileMaker_Layout object that describes the layout of this 
+     * Returns a FileMaker_Layout object that describes the layout of this
      * result set.
      *
      * @return FileMaker_Layout Layout object.
      */
-    function &getLayout()
+    public function &getLayout()
     {
         return $this->_impl->getLayout();
     }
 
     /**
-     * Returns an array containing each record in the result set. 
-     * 
+     * Returns an array containing each record in the result set.
+     *
      * Each member of the array is a FileMaker_Record object, or an
      * instance of the alternate class you specified to use for records
-     * (see {@link FileMaker_Record}. The array may be empty if 
+     * (see {@link FileMaker_Record}. The array may be empty if
      * the result set contains no records.
      *
      * @return array Record objects.
      */
-    function &getRecords()
+    public function &getRecords()
     {
         return $this->_impl->getRecords();
     }
 
     /**
-     * Returns a list of the names of all fields in the records in 
-     * this result set. 
-     * 
-     * Only the field names are returned. If you need additional 
-     * information, examine the Layout object provided by the 
+     * Returns a list of the names of all fields in the records in
+     * this result set.
+     *
+     * Only the field names are returned. If you need additional
+     * information, examine the Layout object provided by the
      * {@link getLayout()} method.
      *
      * @return array List of field names as strings.
      */
-    function getFields()
+    public function getFields()
     {
         return $this->_impl->getFields();
     }
 
     /**
-     * Returns the names of related tables for all portals present in records 
+     * Returns the names of related tables for all portals present in records
      * in this result set.
      *
      * @return array List of related table names as strings.
      */
-    function getRelatedSets()
+    public function getRelatedSets()
     {
         return $this->_impl->getRelatedSets();
     }
@@ -103,7 +103,7 @@ class FileMaker_Result
      *
      * @return integer Total record count in table.
      */
-    function getTableRecordCount()
+    public function getTableRecordCount()
     {
         return $this->_impl->getTableRecordCount();
     }
@@ -113,44 +113,44 @@ class FileMaker_Result
      *
      * @return integer Found record count.
      */
-    function getFoundSetCount()
+    public function getFoundSetCount()
     {
         return $this->_impl->getFoundSetCount();
     }
 
     /**
      * Returns the number of records in the filtered result set.
-     * 
-     * If no range parameters were specified on the Find command, 
+     *
+     * If no range parameters were specified on the Find command,
      * then this value is equal to the result of the {@link getFoundSetCount()}
-     * method. It is always equal to the value of 
+     * method. It is always equal to the value of
      * count($response->{@link getRecords()}).
      *
      * @return integer Filtered record count.
      */
-    function getFetchCount()
+    public function getFetchCount()
     {
         return $this->_impl->getFetchCount();
     }
-    
+
     /**
      * Returns the first record in this result set.
      *
      * @return FileMaker_Record First record.
      */
-    function getFirstRecord()
+    public function getFirstRecord()
     {
-    	return $this->_impl->getFirstRecord();
+        return $this->_impl->getFirstRecord();
     }
-    
+
     /**
      * Returns the last record in this result set.
      *
      * @return FileMaker_Record Last record.
      */
-   	function getLastRecord()
+    public function getLastRecord()
     {
-    	return $this->_impl->getLastRecord();
+        return $this->_impl->getLastRecord();
     }
 
 }


### PR DESCRIPTION
I added the visibility keywords (`public`) and changed old constructor names for `__construct`. It nows works on Homestead with PHP 7.
